### PR TITLE
Add silver foil accents

### DIFF
--- a/src/components/CheckIcon.jsx
+++ b/src/components/CheckIcon.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function CheckIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -1,0 +1,25 @@
+import CheckIcon from './CheckIcon';
+
+export default function Credentials() {
+  const credentials = [
+    'Licensed & Bonded',
+    'Certified Signing Agent',
+    'Member of National Notary Association',
+  ];
+
+  return (
+    <section className="container py-16 space-y-6">
+      <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient">
+        Credentials
+      </h2>
+      <ul className="space-y-4">
+        {credentials.map((cred) => (
+          <li key={cred} className="flex items-start">
+            <CheckIcon className="mr-2 h-5 w-5 text-silver-600" />
+            <span className="text-gray-300">{cred}</span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -13,11 +13,11 @@ export default function Hero() {
         <div className="mx-auto flex h-40 w-40 items-center justify-center rounded-md bg-black text-gray-300 shadow-2xl">
           Logo Reveal Coming Soon
         </div>
-        <h1 className="text-4xl font-serif font-semibold tracking-wide md:text-6xl">Keystone Notary Group</h1>
+        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient md:text-6xl">Keystone Notary Group</h1>
         <p className="text-lg font-light md:text-2xl">Reliable Mobile Notary Services</p>
         <a
           href="#contact"
-          className="inline-block rounded border border-gray-600 bg-[#1a1a1a] px-8 py-3 text-lg font-medium text-white transition hover:shadow-lg"
+          className="inline-block rounded border border-gray-600 bg-[#1a1a1a] px-8 py-3 text-lg font-medium text-white transition hover:text-silver-500 hover:border-silver-500 hover:shadow-lg"
         >
           Request Notary
         </a>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -16,14 +16,14 @@ export default function Navbar() {
   const toggle = () => setOpen(!open);
 
   const linkClasses = ({ isActive }) =>
-    `block rounded px-3 py-2 text-lg font-medium text-gray-200 bg-gray-800 hover:bg-gray-700 hover:shadow ${
-      isActive ? 'shadow-inner' : ''
+    `block rounded px-3 py-2 text-lg font-medium text-gray-200 bg-gray-800 transition-colors hover:text-silver-500 hover:bg-gray-700 hover:shadow ${
+      isActive ? 'text-silver-600 shadow-inner' : ''
     }`;
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 bg-gray-950/70 backdrop-blur">
       <nav className="container flex items-center justify-between py-4">
-        <Link to="/" className="flex items-center text-xl font-semibold">
+        <Link to="/" className="flex items-center text-xl font-semibold transition-colors hover:text-silver-500">
           <img src={logo} alt="Keystone Notary Group" className="h-8 w-8 mr-2" />
           Keystone
         </Link>

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -25,7 +25,7 @@ export default function ScrollToTopButton() {
           transition={{ duration: 0.3 }}
           onClick={handleClick}
           aria-label="Scroll to top"
-          className="fixed bottom-4 right-4 rounded-full bg-[#1a1a1a] p-3 text-white shadow-lg focus:outline-none focus:ring focus:ring-gray-500"
+          className="fixed bottom-4 right-4 rounded-full bg-[#1a1a1a] p-3 text-white transition hover:text-silver-500 shadow-lg focus:outline-none focus:ring focus:ring-gray-500"
         >
           ↑
         </motion.button>

--- a/src/index.css
+++ b/src/index.css
@@ -17,3 +17,19 @@
   background-image: radial-gradient(circle at center, rgba(255,255,255,0.05), transparent 70%);
 }
 
+@layer components {
+  /* Silver underline accent for headings */
+  .heading-gradient {
+    @apply relative pb-2;
+  }
+  .heading-gradient::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 1px;
+    width: 100%;
+    background-image: linear-gradient(to right, #bfbfbf, transparent);
+  }
+}
+

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,7 +1,7 @@
 export default function About() {
   return (
     <section className="container py-16 space-y-6">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide">About Us</h1>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient">About Us</h1>
       <p className="text-lg text-gray-300">
         Keystone Notary Group is dedicated to providing high-quality notary services
         with integrity and professionalism.

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,8 +1,8 @@
 export default function Contact() {
   return (
     <section id="contact" className="container py-16 space-y-6">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide">Contact Us</h1>
-      <p className="text-lg text-gray-300">Email us at <a href="mailto:info@keystonenotarygroup.com" className="underline hover:text-gray-100">info@keystonenotarygroup.com</a></p>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient">Contact Us</h1>
+      <p className="text-lg text-gray-300">Email us at <a href="mailto:info@keystonenotarygroup.com" className="underline transition-colors hover:text-silver-500">info@keystonenotarygroup.com</a></p>
     </section>
   );
 }

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -6,7 +6,7 @@ export default function FAQ() {
 
   return (
     <section className="container py-16 space-y-8">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide">Frequently Asked Questions</h1>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient">Frequently Asked Questions</h1>
       <ul className="space-y-4">
         {faqs.map(({ q, a }) => (
           <li key={q}>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,16 +1,18 @@
 import Hero from '../components/Hero';
+import Credentials from '../components/Credentials';
 
 export default function Home() {
   return (
     <>
       <Hero />
       <section className="container py-16 space-y-8">
-        <h2 className="text-3xl font-serif font-semibold tracking-wide">Why Choose Us?</h2>
+        <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient">Why Choose Us?</h2>
         <p className="text-lg text-gray-300">
           Keystone Notary Group provides professional, reliable, and convenient mobile
           notary services. We bring the notary public to you.
         </p>
       </section>
+      <Credentials />
     </>
   );
 }

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,9 +3,9 @@ import { Link } from 'react-router-dom';
 export default function NotFound() {
   return (
     <section className="container flex min-h-screen flex-col items-center justify-center space-y-6 py-16 text-center">
-      <h1 className="text-6xl font-serif font-semibold tracking-wide">404</h1>
+      <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient">404</h1>
       <p className="text-lg text-gray-300">Page not found.</p>
-      <Link to="/" className="rounded border border-gray-600 bg-[#1a1a1a] px-6 py-3 text-white hover:shadow-lg">
+      <Link to="/" className="rounded border border-gray-600 bg-[#1a1a1a] px-6 py-3 text-white transition hover:text-silver-500 hover:border-silver-500 hover:shadow-lg">
         Back to Home
       </Link>
     </section>

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -8,7 +8,7 @@ export default function Services() {
 
   return (
     <section className="container py-16 space-y-8">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide">Services</h1>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient">Services</h1>
       <ul className="grid gap-4 md:grid-cols-2">
         {services.map((service) => (
           <li key={service} className="rounded bg-gray-800 p-4">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,6 +13,11 @@ export default {
           500: '#2d8aac',
           600: '#197189',
         },
+        silver: {
+          400: '#999999',
+          500: '#adadad',
+          600: '#bfbfbf',
+        },
       },
       container: {
         center: true,


### PR DESCRIPTION
## Summary
- implement a silver color palette and heading underline effect
- add credentials section with checkmark icons
- highlight navigation and buttons with silver hover states
- apply accents to headings across pages

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6868dd473e1c8327aafa776cdf514c44