### PR TITLE
Refine hero background and cleanup CSS

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion';
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-screen items-center justify-center bg-hero bg-cover bg-center text-center">
+    <section className="relative flex min-h-screen items-center justify-center bg-charcoal text-center px-4">
       <div className="absolute inset-0 bg-black/80" />
       <motion.div
         initial={{ opacity: 0, y: 20 }}
@@ -10,7 +10,7 @@ export default function Hero() {
         transition={{ duration: 0.8 }}
         className="relative z-10 space-y-6"
       >
-        <div className="mx-auto flex h-40 w-40 items-center justify-center rounded-md bg-black text-platinum shadow-2xl">
+        <div className="mx-auto flex h-40 w-40 items-center justify-center rounded-md bg-black text-platinum shadow-lg">
           Logo Reveal Coming Soon
         </div>
         <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient md:text-6xl">Keystone Notary Group</h1>

--- a/src/index.css
+++ b/src/index.css
@@ -4,17 +4,9 @@
 
 @layer base {
   body {
-    @apply bg-[#121212] text-platinum font-sans;
-    /* Subtle texture and depth */
-    background-image:
-      radial-gradient(circle at center, rgba(255,255,255,0.05), transparent 70%),
-      repeating-linear-gradient(45deg, rgba(255,255,255,0.02) 0, rgba(255,255,255,0.02) 1px, transparent 1px, transparent 5px);
-    background-size: 100% 100%, 40px 40px;
+    @apply bg-charcoal text-platinum font-sans;
+    /* Keep the background clean with no decorative textures */
   }
-}
-
-.bg-hero {
-  background-image: radial-gradient(circle at center, rgba(255,255,255,0.05), transparent 70%);
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
- remove decorative gradients and hero background
- simplify hero styling and spacing
- use clean charcoal page background

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6868e4241be88327b7da6f05d0f7a3d6