### PR TITLE
Expand About page content

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ This file outlines features, improvements, and implementation tasks for Codex to
 
 ## Priority Features to Add
 
-- [ ] Create a full About page with company overview, professionalism, and mission statement.
+- [x] Create a full About page with company overview, professionalism, and mission statement.
 - [ ] Create a full Services page listing all notarial offerings in a well-structured layout.
 - [ ] Build a styled FAQ page with accessible, collapsible Q&A components.
 - [ ] Enhance the Contact form with fields for appointment type and document category.

--- a/src/__tests__/About.test.jsx
+++ b/src/__tests__/About.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+
+test('renders about page content', () => {
+  render(
+    <MemoryRouter initialEntries={['/about']}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('heading', { name: /about us/i })).toBeInTheDocument();
+  expect(
+    screen.getByText(/Pennsylvania-commissioned mobile notary company/i)
+  ).toBeInTheDocument();
+  expect(screen.getByRole('link', { name: /back to home/i })).toHaveAttribute('href', '/');
+});

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,13 +1,44 @@
+import { Link } from 'react-router-dom';
 import MotionSection from '../components/MotionSection';
 
 export default function About() {
   return (
-    <MotionSection className="container space-y-6">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">About Us</h1>
+    <MotionSection className="relative container space-y-8 py-8">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 opacity-20 [background:radial-gradient(circle_at_center,_rgba(255,255,255,0.05),_transparent)]"
+      />
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        About Us
+      </h1>
       <p className="text-lg text-platinum">
-        Keystone Notary Group is dedicated to providing high-quality notary services
-        with integrity and professionalism.
+        Keystone Notary Group, LLC is a Pennsylvania-commissioned mobile notary
+        company serving the Greater Philadelphia area.
       </p>
+      <p className="text-lg text-platinum">
+        We provide in-person notarizations to individuals, attorneys, financial
+        institutions, and the general public. All agents are NNA Certified
+        Notary Signing Agents with current background checks and are bonded and
+        insured.
+      </p>
+      <p className="text-lg text-platinum">
+        Known for professionalism, punctuality, confidentiality, and document
+        accuracy, we also offer after-hours and emergency notarizations for
+        time-sensitive needs.
+      </p>
+      <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        Service Area
+      </h2>
+      <p className="text-lg text-platinum">
+        Our notaries travel throughout Bucks, Montgomery, Philadelphia, Delaware,
+        and Chester Counties.
+      </p>
+      <Link
+        to="/"
+        className="cta-button mt-4 inline-block hover:border-silver hover:text-silver"
+      >
+        Back to Home
+      </Link>
     </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- flesh out About page with professional copy and radial background
- add "Back to Home" button for easier navigation
- check off TODO item for About page completion
- test About page rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_6868efdda19c8327a07ba176620a04cc