### PR TITLE
Setup Vitest and finalize Services page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.6.0",
+        "@vitest/ui": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "jsdom": "^26.1.0",
         "postcss": "^8.5.6",
@@ -985,6 +986,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
@@ -1598,6 +1606,28 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
+      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.4"
       }
     },
     "node_modules/@vitest/utils": {
@@ -2271,6 +2301,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2283,6 +2320,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2833,6 +2877,16 @@
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
       "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -3563,6 +3617,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3961,6 +4030,16 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest --watch"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",
@@ -20,6 +20,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "jsdom": "^26.1.0",
     "postcss": "^8.5.6",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { Routes, Route } from 'react-router-dom';
-import Layout from './components/Layout';
+import { Layout } from './components';
 import Home from './pages/Home';
 import About from './pages/About';
 import Services from './pages/Services';

--- a/src/__tests__/Footer.test.jsx
+++ b/src/__tests__/Footer.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import Footer from '../components/Footer';
+import { Footer } from '../components';
 
 test('displays current year', () => {
   render(<Footer />);

--- a/src/__tests__/Layout.test.jsx
+++ b/src/__tests__/Layout.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import Layout from '../components/Layout';
+import { Layout } from '../components';
 
 // Ensure the layout always has router context
 describe('Layout component', () => {

--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import Navbar from '../components/Navbar';
+import { Navbar } from '../components';
 
 test('toggles mobile menu', async () => {
   render(

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,8 @@
+export { default as CheckIcon } from './CheckIcon';
+export { default as Credentials } from './Credentials';
+export { default as Footer } from './Footer';
+export { default as Hero } from './Hero';
+export { default as Layout } from './Layout';
+export { default as MotionSection } from './MotionSection';
+export { default as Navbar } from './Navbar';
+export { default as ScrollToTopButton } from './ScrollToTopButton';

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import MotionSection from '../components/MotionSection';
+import { MotionSection } from '../components';
 
 export default function About() {
   return (

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import MotionSection from '../components/MotionSection';
+import { MotionSection } from '../components';
 
 export default function Contact() {
   const [submitted, setSubmitted] = useState(false);

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -1,4 +1,4 @@
-import MotionSection from '../components/MotionSection';
+import { MotionSection } from '../components';
 
 export default function FAQ() {
   const faqs = [

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,4 @@
-import Hero from '../components/Hero';
-import Credentials from '../components/Credentials';
-import MotionSection from '../components/MotionSection';
+import { Hero, Credentials, MotionSection } from '../components';
 
 export default function Home() {
   return (

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import MotionSection from '../components/MotionSection';
+import { MotionSection } from '../components';
 
 export default function NotFound() {
   return (

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,20 +1,42 @@
-import MotionSection from '../components/MotionSection';
+import { MotionSection } from '../components';
 
 export default function Services() {
   const services = [
-    'Acknowledgements',
-    'Jurats',
-    'Loan Signings',
-    'Apostille Facilitation',
+    {
+      title: 'Acknowledgements & Jurats',
+      desc: 'Official witnessing of signatures and sworn statements.',
+    },
+    {
+      title: 'Loan Signing Services',
+      desc: 'Professional handling of mortgage closings and refinance packages.',
+    },
+    {
+      title: 'Apostille Facilitation',
+      desc: 'Guidance obtaining apostilles for documents destined for foreign use.',
+    },
+    {
+      title: 'I-9 Employment Verification',
+      desc: 'Authorized representative services for remote employee onboarding.',
+    },
+    {
+      title: 'Remote Notarization',
+      desc: 'Online notarization where permitted by Pennsylvania law.',
+    },
   ];
 
   return (
     <MotionSection className="container space-y-8">
-      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">Services</h1>
-      <ul className="grid gap-4 md:grid-cols-2">
-        {services.map((service) => (
-          <li key={service} className="rounded border border-platinum bg-deepgray p-4">
-            {service}
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        Services
+      </h1>
+      <ul className="grid gap-6 md:grid-cols-2">
+        {services.map(({ title, desc }) => (
+          <li
+            key={title}
+            className="rounded border border-platinum bg-deepgray p-4 shadow-sm"
+          >
+            <h2 className="text-xl font-semibold text-platinum">{title}</h2>
+            <p className="mt-2 text-platinum">{desc}</p>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add Vitest UI and watch script
- export all components from a single index
- refactor imports to use index exports
- build out Services page with detailed offerings

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_6868f409705c83278676be7905d21668