### PR TITLE
Improve mobile menu background

### DIFF
--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -12,6 +12,10 @@ test('toggles mobile menu', async () => {
   const button = screen.getByRole('button', { name: /toggle navigation/i });
   fireEvent.click(button);
   expect(screen.getByRole('button', { name: /close navigation/i })).toBeInTheDocument();
+  // Mobile menu should render with a navigation region for accessibility
+  expect(
+    screen.getByRole('navigation', { name: /mobile navigation/i })
+  ).toBeInTheDocument();
 
   const close = screen.getByRole('button', { name: /close navigation/i });
   fireEvent.click(close);

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -67,20 +67,23 @@ export default function Navbar() {
             >
               ✕
             </button>
-            <ul className="mt-8 space-y-4">
-              {navItems.map((item) => (
-                <li key={item.name}>
-                  <NavLink
-                    to={item.path}
-                    className={linkClasses}
-                    onClick={() => setOpen(false)}
-                    end
-                  >
-                    {item.name}
-                  </NavLink>
-                </li>
-              ))}
-            </ul>
+            {/* Mobile menu with a solid background behind item gaps */}
+            <nav aria-label="Mobile navigation" className="mt-8">
+              <ul className="space-y-4 bg-black">
+                {navItems.map((item) => (
+                  <li key={item.name}>
+                    <NavLink
+                      to={item.path}
+                      className={linkClasses}
+                      onClick={() => setOpen(false)}
+                      end
+                    >
+                      {item.name}
+                    </NavLink>
+                  </li>
+                ))}
+              </ul>
+            </nav>
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- add solid background behind mobile menu items
- add accessibility test for the mobile menu

## Testing
- `npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_b_6868ffa93df88327837d458467343c7b