### PR TITLE
Enable optional appointment scheduling in contact form

### DIFF
--- a/src/__tests__/Contact.test.jsx
+++ b/src/__tests__/Contact.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../App';
 
@@ -10,11 +11,28 @@ function setup() {
   );
 }
 
-test('renders contact form', () => {
+test('renders contact form', async () => {
   setup();
   expect(screen.getByRole('heading', { name: /contact us/i })).toBeInTheDocument();
   expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
   expect(
     screen.getByText(/Submitting this form does not guarantee an appointment/i)
   ).toBeInTheDocument();
+  // appointment scheduling elements
+  const checkbox = screen.getByLabelText(/i am requesting an appointment/i);
+  let dateInput = screen.getByLabelText(/preferred date/i);
+  let timeInput = screen.getByLabelText(/preferred time/i);
+  expect(checkbox).toBeInTheDocument();
+  expect(dateInput).toBeDisabled();
+  expect(timeInput).toBeDisabled();
+
+  // enable appointment fields
+  await userEvent.click(checkbox);
+  // re-query inputs after state update
+  dateInput = screen.getByLabelText(/preferred date/i);
+  timeInput = screen.getByLabelText(/preferred time/i);
+  expect(dateInput).toBeEnabled();
+  expect(dateInput).toBeRequired();
+  expect(timeInput).toBeEnabled();
+  expect(timeInput).toBeRequired();
 });

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -3,11 +3,13 @@ import { MotionSection } from '../components';
 
 export default function Contact() {
   const [submitted, setSubmitted] = useState(false);
+  const [requestAppointment, setRequestAppointment] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     email: '',
     phone: '',
-    datetime: '',
+    date: '',
+    time: '',
     message: '',
   });
 
@@ -74,17 +76,48 @@ export default function Contact() {
               className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none"
             />
           </label>
-          <label className="block" htmlFor="datetime">
-            <span className="mb-1 block text-platinum">Preferred Appointment Date/Time</span>
+          <label className="flex items-center gap-2 md:col-span-2" htmlFor="requestAppointment">
             <input
-              id="datetime"
-              name="datetime"
-              type="datetime-local"
-              value={formData.datetime}
+              id="requestAppointment"
+              name="requestAppointment"
+              type="checkbox"
+              checked={requestAppointment}
+              onChange={(e) => setRequestAppointment(e.target.checked)}
+              className="h-5 w-5 accent-silver"
+            />
+            <span className="text-platinum">I am requesting an appointment.</span>
+          </label>
+          <label className="block" htmlFor="date">
+            <span className="mb-1 block text-platinum">Preferred Date</span>
+            <input
+              id="date"
+              name="date"
+              type="date"
+              disabled={!requestAppointment}
+              required={requestAppointment}
+              value={formData.date}
               onChange={handleChange}
-              className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none"
+              className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
             />
           </label>
+          <label className="block" htmlFor="time">
+            <span className="mb-1 block text-platinum">Preferred Time</span>
+            <input
+              id="time"
+              name="time"
+              type="time"
+              disabled={!requestAppointment}
+              required={requestAppointment}
+              value={formData.time}
+              onChange={handleChange}
+              className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+            />
+          </label>
+          {!requestAppointment && (
+            <p className="md:col-span-2 text-xs italic text-platinum">
+              Enable appointment request above to choose date and time.
+            </p>
+          )}
         </div>
         <label className="block" htmlFor="message">
           <span className="mb-1 block text-platinum">Message</span>


### PR DESCRIPTION
## Summary
- add checkbox to request appointments
- disable date/time inputs unless checkbox is selected
- give user feedback when fields are disabled
- update test to cover new interactive behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686a116145188327a89569968279e0df