### PR TITLE
Fix contact CTA routing

### DIFF
--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -10,5 +10,5 @@ test('renders home page heading and cta', () => {
   );
   expect(screen.getByRole('heading', { name: /keystone notary group/i })).toBeInTheDocument();
   const cta = screen.getByRole('link', { name: /schedule appointment/i });
-  expect(cta).toHaveAttribute('href', '/contact');
+  expect(cta).toHaveAttribute('href', '/contact#contact');
 });

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,4 +1,7 @@
 import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+
+const MotionLink = motion(Link);
 
 export default function Hero() {
   return (
@@ -17,13 +20,13 @@ export default function Hero() {
           Keystone Notary Group, LLC
         </h1>
         <p className="text-lg font-light md:text-2xl">Reliable Mobile Notary Services</p>
-        <motion.a
-          href="/contact"
+        <MotionLink
+          to="/contact#contact"
           whileHover={{ y: -2, boxShadow: '0 4px 15px rgba(255,255,255,0.15)' }}
           className="cta-button hover:border-silver hover:text-silver"
         >
           Schedule Appointment
-        </motion.a>
+        </MotionLink>
       </motion.div>
     </section>
   );

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,9 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { MotionSection } from '../components';
 
 export default function Contact() {
   const [submitted, setSubmitted] = useState(false);
   const [requestAppointment, setRequestAppointment] = useState(false);
+  const location = useLocation();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
@@ -22,6 +24,16 @@ export default function Contact() {
     // In the future, form data can be sent to the backend for owner review
     setSubmitted(true);
   };
+
+  useEffect(() => {
+    if (location.hash) {
+      const id = location.hash.substring(1);
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [location]);
 
   if (submitted) {
     return (


### PR DESCRIPTION
## Summary
- use React Router link in hero button and point to contact anchor
- scroll to the contact form when arriving on `/contact#contact`
- update home page test for new path

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_b_686a8d6eb52c83279107312a138a9015