### PR TITLE
Add form validation on contact page

### DIFF
--- a/src/__tests__/Contact.test.jsx
+++ b/src/__tests__/Contact.test.jsx
@@ -14,28 +14,38 @@ function setup() {
   );
 }
 
-test('renders contact form', async () => {
+test('renders contact form and validates fields', async () => {
   setup();
+  const user = userEvent.setup();
   expect(screen.getByRole('heading', { name: /contact us/i })).toBeInTheDocument();
   expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
   expect(
     screen.getByText(/Submitting this form does not guarantee an appointment/i)
   ).toBeInTheDocument();
-  // appointment scheduling elements
+
   const checkbox = screen.getByLabelText(/i am requesting an appointment/i);
   let dateInput = screen.getByLabelText(/preferred date/i);
   let timeInput = screen.getByLabelText(/preferred time/i);
-  expect(checkbox).toBeInTheDocument();
   expect(dateInput).toBeDisabled();
   expect(timeInput).toBeDisabled();
 
+  const submitButton = screen.getByRole('button', { name: /send message/i });
+  await user.click(submitButton);
+  expect(screen.getByText(/full name is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/email address is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/message is required/i)).toBeInTheDocument();
+  expect(screen.queryByText(/preferred date is required/i)).not.toBeInTheDocument();
+
   // enable appointment fields
-  await userEvent.click(checkbox);
-  // re-query inputs after state update
+  await user.click(checkbox);
   dateInput = screen.getByLabelText(/preferred date/i);
   timeInput = screen.getByLabelText(/preferred time/i);
   expect(dateInput).toBeEnabled();
   expect(dateInput).toBeRequired();
   expect(timeInput).toBeEnabled();
   expect(timeInput).toBeRequired();
+
+  await user.click(submitButton);
+  expect(screen.getByText(/preferred date is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/preferred time is required/i)).toBeInTheDocument();
 });

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -14,14 +14,49 @@ export default function Contact() {
     time: '',
     message: '',
   });
+  const [errors, setErrors] = useState({});
+
+  const validate = () => {
+    const newErrors = {};
+    if (!formData.name.trim()) {
+      newErrors.name = 'Full name is required.';
+    }
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email address is required.';
+    } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
+      newErrors.email = 'Enter a valid email address.';
+    }
+    if (!formData.message.trim()) {
+      newErrors.message = 'Message is required.';
+    }
+    if (requestAppointment) {
+      if (!formData.date) {
+        newErrors.date = 'Preferred date is required.';
+      }
+      if (!formData.time) {
+        newErrors.time = 'Preferred time is required.';
+      }
+    }
+    return newErrors;
+  };
 
   const handleChange = (e) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+    if (errors[name]) {
+      setErrors({ ...errors, [name]: '' });
+    }
   };
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    const validation = validate();
+    if (Object.keys(validation).length > 0) {
+      setErrors(validation);
+      return;
+    }
     // In the future, form data can be sent to the backend for owner review
+    setErrors({});
     setSubmitted(true);
   };
 
@@ -62,8 +97,14 @@ export default function Contact() {
               required
               value={formData.name}
               onChange={handleChange}
+              aria-invalid={!!errors.name}
               className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none"
             />
+            {errors.name && (
+              <p role="alert" className="mt-1 text-sm text-red-500">
+                {errors.name}
+              </p>
+            )}
           </label>
           <label className="block" htmlFor="email">
             <span className="mb-1 block text-platinum">Email Address</span>
@@ -74,8 +115,14 @@ export default function Contact() {
               required
               value={formData.email}
               onChange={handleChange}
+              aria-invalid={!!errors.email}
               className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none"
             />
+            {errors.email && (
+              <p role="alert" className="mt-1 text-sm text-red-500">
+                {errors.email}
+              </p>
+            )}
           </label>
           <label className="block" htmlFor="phone">
             <span className="mb-1 block text-platinum">Phone Number</span>
@@ -94,7 +141,16 @@ export default function Contact() {
               name="requestAppointment"
               type="checkbox"
               checked={requestAppointment}
-              onChange={(e) => setRequestAppointment(e.target.checked)}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setRequestAppointment(checked);
+                if (!checked) {
+                  setErrors((prev) => {
+                    const { date, time, ...rest } = prev;
+                    return rest;
+                  });
+                }
+              }}
               className="h-5 w-5 accent-silver"
             />
             <span className="text-platinum">I am requesting an appointment.</span>
@@ -109,8 +165,14 @@ export default function Contact() {
               required={requestAppointment}
               value={formData.date}
               onChange={handleChange}
+              aria-invalid={!!errors.date}
               className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
             />
+            {errors.date && (
+              <p role="alert" className="mt-1 text-sm text-red-500">
+                {errors.date}
+              </p>
+            )}
           </label>
           <label className="block" htmlFor="time">
             <span className="mb-1 block text-platinum">Preferred Time</span>
@@ -122,8 +184,14 @@ export default function Contact() {
               required={requestAppointment}
               value={formData.time}
               onChange={handleChange}
+              aria-invalid={!!errors.time}
               className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
             />
+            {errors.time && (
+              <p role="alert" className="mt-1 text-sm text-red-500">
+                {errors.time}
+              </p>
+            )}
           </label>
           {!requestAppointment && (
             <p className="md:col-span-2 text-xs italic text-platinum">
@@ -140,8 +208,14 @@ export default function Contact() {
             rows="4"
             value={formData.message}
             onChange={handleChange}
+            aria-invalid={!!errors.message}
             className="w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none"
           />
+          {errors.message && (
+            <p role="alert" className="mt-1 text-sm text-red-500">
+              {errors.message}
+            </p>
+          )}
         </label>
         <button
           type="submit"


### PR DESCRIPTION
## Summary
- add validation errors state to the Contact page
- display accessible error messages for each field
- validate required inputs on submit and clear errors on change
- update tests to cover validation feedback

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686ae53379ec8327bacdaaeaeb17e0ff