### PR TITLE
Improve router config and mobile layout

### DIFF
--- a/src/__tests__/About.test.jsx
+++ b/src/__tests__/About.test.jsx
@@ -6,7 +6,7 @@ test('renders about page content', () => {
   render(
     <MemoryRouter
       initialEntries={['/about']}
-      future={{ v7_relativeSplatPath: true }}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <App />
     </MemoryRouter>

--- a/src/__tests__/Contact.test.jsx
+++ b/src/__tests__/Contact.test.jsx
@@ -7,7 +7,7 @@ function setup() {
   render(
     <MemoryRouter
       initialEntries={['/contact']}
-      future={{ v7_relativeSplatPath: true }}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <App />
     </MemoryRouter>

--- a/src/__tests__/FAQ.test.jsx
+++ b/src/__tests__/FAQ.test.jsx
@@ -4,7 +4,7 @@ import App from '../App';
 
 function setup() {
   render(
-    <MemoryRouter initialEntries={["/faq"]} future={{ v7_relativeSplatPath: true }}>
+    <MemoryRouter initialEntries={["/faq"]} future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <App />
     </MemoryRouter>
   );

--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -4,7 +4,7 @@ import App from '../App';
 
 test('renders home page heading and cta', () => {
   render(
-    <MemoryRouter initialEntries={["/"]} future={{ v7_relativeSplatPath: true }}>
+    <MemoryRouter initialEntries={["/"]} future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <App />
     </MemoryRouter>
   );

--- a/src/__tests__/Layout.test.jsx
+++ b/src/__tests__/Layout.test.jsx
@@ -6,7 +6,7 @@ import { Layout } from '../components';
 describe('Layout component', () => {
   test('renders header and footer', () => {
     render(
-      <MemoryRouter future={{ v7_relativeSplatPath: true }}>
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
         <Layout />
       </MemoryRouter>
     );

--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -9,7 +9,7 @@ import { Navbar } from "../components";
 
 test("toggles mobile menu", async () => {
   render(
-    <MemoryRouter future={{ v7_relativeSplatPath: true }}>
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <Navbar />
     </MemoryRouter>,
   );

--- a/src/__tests__/Navigation.test.jsx
+++ b/src/__tests__/Navigation.test.jsx
@@ -4,7 +4,7 @@ import App from '../App';
 
 function setup() {
   render(
-    <MemoryRouter initialEntries={["/"]} future={{ v7_relativeSplatPath: true }}>
+    <MemoryRouter initialEntries={["/"]} future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <App />
     </MemoryRouter>
   );

--- a/src/__tests__/Services.test.jsx
+++ b/src/__tests__/Services.test.jsx
@@ -6,7 +6,7 @@ function setup() {
   render(
     <MemoryRouter
       initialEntries={['/services']}
-      future={{ v7_relativeSplatPath: true }}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <App />
     </MemoryRouter>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter future={{ v7_relativeSplatPath: true }}>
+    <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <App />
     </BrowserRouter>
   </React.StrictMode>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -87,7 +87,7 @@ export default function Contact() {
         Contact Us
       </h1>
       <form onSubmit={handleSubmit} className="space-y-6" noValidate>
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-4 min-[568px]:grid-cols-2">
           <label className="block" htmlFor="name">
             <span className="mb-1 block text-platinum">Full Name</span>
             <input

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -33,7 +33,7 @@ export default function Services() {
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Services
       </h1>
-      <ul className="grid gap-6 md:grid-cols-2">
+      <ul className="grid gap-6 min-[568px]:grid-cols-2">
         {services.map(({ title, desc }) => (
           <li
             key={title}


### PR DESCRIPTION
## Summary
- enable React Router v7 transition flags across app and tests
- tweak contact form grid for smaller landscape screens
- adjust services grid for better mobile layout

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686aeefd6c68832797b5750783363af3