### PR TITLE
Add call or text info on homepage

### DIFF
--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -11,6 +11,8 @@ test('renders home page heading and cta', () => {
   expect(screen.getByRole('heading', { name: /keystone notary group/i })).toBeInTheDocument();
   const cta = screen.getByRole('link', { name: /schedule appointment/i });
   expect(cta).toHaveAttribute('href', '/contact#contact');
+  const phoneLink = screen.getByRole('link', { name: /call or text/i });
+  expect(phoneLink).toHaveAttribute('href', 'tel:2673099000');
   // Logo should render with accessible alt text
   expect(screen.getByAltText(/keystone notary group logo/i)).toBeInTheDocument();
 });

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
+import PhoneIcon from './PhoneIcon';
 
 // framer-motion 11 deprecates `motion()` in favor of `motion.create()`
 // Use the new API to avoid deprecation warnings during tests
@@ -7,7 +8,7 @@ const MotionLink = motion.create(Link);
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-screen items-center justify-center bg-charcoal text-center">
+    <section className="relative flex min-h-screen items-center justify-center text-center">
       {/* Semi-transparent overlay for better text readability over the background */}
       <div className="absolute inset-0 bg-black/80" />
       <motion.div
@@ -26,6 +27,14 @@ export default function Hero() {
           Keystone Notary Group, LLC
         </h1>
         <p className="text-lg font-light md:text-2xl">Reliable Mobile Notary Services</p>
+        <a
+          href="tel:2673099000"
+          aria-label="Call or text 267-309-9000"
+          className="flex items-center justify-center gap-2 py-2 text-platinum hover:text-silver focus:outline-none focus:ring focus:ring-platinum"
+        >
+          <PhoneIcon className="h-5 w-5" />
+          <span className="whitespace-nowrap">Call or Text: (267) 309-9000</span>
+        </a>
         <MotionLink
           to="/contact#contact"
           whileHover={{ y: -2, boxShadow: '0 4px 15px rgba(255,255,255,0.15)' }}

--- a/src/components/PhoneIcon.jsx
+++ b/src/components/PhoneIcon.jsx
@@ -1,0 +1,19 @@
+export default function PhoneIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 6.75c0 8.284 6.716 15 15 15h2.25a2.25 2.25 0 002.25-2.25v-1.372c0-.516-.351-.966-.852-1.091l-4.423-1.106a1.125 1.125 0 00-1.173.417l-.97 1.293a1.125 1.125 0 01-1.21.38 12.035 12.035 0 01-7.143-7.143 1.125 1.125 0 01.38-1.21l1.293-.97c.363-.271.527-.734.417-1.173L6.963 3.102A1.125 1.125 0 006.112 2.25H4.5A2.25 2.25 0 002.25 4.5v2.25z"
+      />
+    </svg>
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,3 +7,4 @@ export { default as MotionSection } from './MotionSection';
 export { default as Navbar } from './Navbar';
 export { default as ScrollToTopButton } from './ScrollToTopButton';
 export { default as StructuredData } from './StructuredData';
+export { default as PhoneIcon } from './PhoneIcon';


### PR DESCRIPTION
## Summary
- add new `PhoneIcon` component
- insert clickable call-or-text link in Hero section
- export `PhoneIcon`
- test for call link on homepage

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686afa0664148327bb6933f0485f7573