### PR TITLE
Add sitemap generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.4",
         "vite": "^7.0.2",
+        "vite-plugin-sitemap": "^0.8.2",
         "vitest": "^3.2.4"
       }
     },
@@ -4252,6 +4253,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/vite-plugin-sitemap": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-sitemap/-/vite-plugin-sitemap-0.8.2.tgz",
+      "integrity": "sha512-bqIw6NVOXg6je81lzX8Lm0vjf8/QSAp8di8fYQzZ3ZdVicOm8+6idBGALJiy1R1FiXNIK8rgORO6HBqXyHW+iQ==",
+      "dev": true
     },
     "node_modules/vite/node_modules/fdir": {
       "version": "6.4.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite build && cp dist/sitemap.xml public/sitemap.xml",
     "preview": "vite preview",
     "test": "vitest --watch"
   },
@@ -26,6 +26,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.4",
     "vite": "^7.0.2",
+    "vite-plugin-sitemap": "^0.8.2",
     "vitest": "^3.2.4"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://keystonenotarygroup.com/sitemap.xml

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import sitemap from 'vite-plugin-sitemap'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    sitemap({
+      hostname: 'https://keystonenotarygroup.com',
+      generateRobotsTxt: false,
+    }),
+  ],
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.js',


### PR DESCRIPTION
## Summary
- generate sitemap with `vite-plugin-sitemap`
- copy sitemap to the public folder after build
- provide a robots.txt that references the sitemap

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686b08b84e2483278aeaa67a7cc76e50