### PR TITLE
Improve SEO across site with structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
     <meta name="twitter:title" content="Keystone Notary Group, LLC" />
     <meta name="twitter:description" content="Professional mobile notary services." />
     <meta name="twitter:image" content="/logo.svg" />
+    <link rel="canonical" href="https://www.keystonenotarygroup.com/" />
+    <link rel="robots" href="/robots.txt" />
+    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@500;600&display=swap"

--- a/src/__tests__/SEO.test.jsx
+++ b/src/__tests__/SEO.test.jsx
@@ -1,0 +1,23 @@
+import { MemoryRouter } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import SEO from '../components/SEO';
+
+it('updates head tags for a page', () => {
+  render(
+    <MemoryRouter initialEntries={['/test']}>
+      <SEO title="Test Title" description="desc" path="/test" />
+    </MemoryRouter>
+  );
+  expect(document.title).toBe('Test Title');
+  const canonical = document.head.querySelector('link[rel="canonical"]');
+  expect(canonical).toHaveAttribute('href', 'https://www.keystonenotarygroup.com/test');
+  const metaDesc = document.head.querySelector('meta[name="description"]');
+  expect(metaDesc).toHaveAttribute('content', 'desc');
+  const og = document.head.querySelector('meta[property="og:title"]');
+  expect(og).toHaveAttribute('content', 'Test Title');
+  const scripts = Array.from(document.head.querySelectorAll('script[type="application/ld+json"]'));
+  const hasWebPage = scripts.some((s) => JSON.parse(s.textContent || '{}')['@type'] === 'WebPage');
+  const hasBreadcrumb = scripts.some((s) => JSON.parse(s.textContent || '{}')['@type'] === 'BreadcrumbList');
+  expect(hasWebPage).toBe(true);
+  expect(hasBreadcrumb).toBe(true);
+});

--- a/src/__tests__/StructuredData.test.jsx
+++ b/src/__tests__/StructuredData.test.jsx
@@ -2,15 +2,17 @@ import { render } from '@testing-library/react';
 import StructuredData from '../components/StructuredData';
 
 // Ensure JSON-LD script is added to document head
-it('inserts local business structured data', () => {
+it('inserts organization and business structured data', () => {
   const { unmount } = render(<StructuredData />);
   const script = document.head.querySelector('script[type="application/ld+json"]');
   expect(script).toBeTruthy();
   if (script) {
     const data = JSON.parse(script.textContent || '{}');
-    expect(data['@type']).toBe('LocalBusiness');
-    // Ensure the correct phone number is rendered
-    expect(data.telephone).toBe('(267) 309-9000');
+    expect(Array.isArray(data['@graph'])).toBe(true);
+    const org = data['@graph'].find((d) => d['@type'] === 'Organization');
+    const business = data['@graph'].find((d) => d['@type'] === 'LocalBusiness');
+    expect(org).toBeTruthy();
+    expect(business.telephone).toBe('(267) 309-9000');
   }
   unmount();
   expect(document.head.querySelector('script[type="application/ld+json"]')).toBeNull();

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -1,0 +1,81 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+/**
+ * Updates document head metadata for SEO and social sharing.
+ * Also injects WebPage and BreadcrumbList JSON-LD structured data.
+ */
+export default function SEO({ title, description, path = '' }) {
+  const location = useLocation();
+
+  useEffect(() => {
+    const baseUrl = 'https://www.keystonenotarygroup.com';
+    const url = baseUrl + (path || location.pathname);
+    const image = `${baseUrl}/logo.svg`;
+
+    const upsertMeta = (name, content, property = false) => {
+      const selector = property ? `meta[property="${name}"]` : `meta[name="${name}"]`;
+      let tag = document.head.querySelector(selector);
+      if (!tag) {
+        tag = document.createElement('meta');
+        tag.setAttribute(property ? 'property' : 'name', name);
+        document.head.appendChild(tag);
+      }
+      tag.setAttribute('content', content);
+    };
+
+    const upsertLink = (rel, href) => {
+      let tag = document.head.querySelector(`link[rel="${rel}"]`);
+      if (!tag) {
+        tag = document.createElement('link');
+        tag.setAttribute('rel', rel);
+        document.head.appendChild(tag);
+      }
+      tag.setAttribute('href', href);
+    };
+
+    document.title = title;
+    upsertMeta('description', description);
+    upsertMeta('og:title', title, true);
+    upsertMeta('og:description', description, true);
+    upsertMeta('og:type', 'website', true);
+    upsertMeta('og:url', url, true);
+    upsertMeta('og:image', image, true);
+    upsertMeta('twitter:card', 'summary_large_image');
+    upsertMeta('twitter:title', title);
+    upsertMeta('twitter:description', description);
+    upsertMeta('twitter:image', image);
+    upsertLink('canonical', url);
+
+    const pageData = {
+      '@context': 'https://schema.org',
+      '@type': 'WebPage',
+      name: title,
+      url,
+      isPartOf: { '@id': baseUrl + '/#website' },
+    };
+
+    const breadcrumb = {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        { '@type': 'ListItem', position: 1, name: 'Home', item: baseUrl },
+        { '@type': 'ListItem', position: 2, name: title, item: url },
+      ],
+    };
+
+    const scripts = [pageData, breadcrumb].map((data) => {
+      const script = document.createElement('script');
+      script.type = 'application/ld+json';
+      script.text = JSON.stringify(data);
+      document.head.appendChild(script);
+      return script;
+    });
+
+    return () => {
+      scripts.forEach((s) => document.head.removeChild(s));
+    };
+  }, [title, description, path, location.pathname]);
+
+  return null;
+}

--- a/src/components/StructuredData.jsx
+++ b/src/components/StructuredData.jsx
@@ -6,19 +6,46 @@ import { useEffect } from 'react';
  */
 export default function StructuredData() {
   useEffect(() => {
+    const baseUrl = 'https://www.keystonenotarygroup.com';
     const data = {
-      "@context": "https://schema.org",
-      "@type": "LocalBusiness",
-      name: "Keystone Notary Group, LLC",
-      url: "https://www.keystonenotarygroup.com",
-      // Keystone's public business line
-      telephone: "(267) 309-9000",
-      address: {
-        "@type": "PostalAddress",
-        addressLocality: "Philadelphia",
-        addressRegion: "PA",
-        addressCountry: "US",
-      },
+      '@context': 'https://schema.org',
+      '@graph': [
+        {
+          '@type': 'Organization',
+          '@id': `${baseUrl}/#organization`,
+          name: 'Keystone Notary Group, LLC',
+          url: baseUrl,
+          logo: `${baseUrl}/logo.svg`,
+          telephone: '(267) 309-9000',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Philadelphia',
+            addressRegion: 'PA',
+            addressCountry: 'US',
+          },
+        },
+        {
+          '@type': 'LocalBusiness',
+          '@id': `${baseUrl}/#business`,
+          name: 'Keystone Notary Group, LLC',
+          url: baseUrl,
+          image: `${baseUrl}/logo.svg`,
+          telephone: '(267) 309-9000',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Philadelphia',
+            addressRegion: 'PA',
+            addressCountry: 'US',
+          },
+        },
+        {
+          '@type': 'WebSite',
+          '@id': `${baseUrl}/#website`,
+          url: baseUrl,
+          name: 'Keystone Notary Group, LLC',
+          publisher: { '@id': `${baseUrl}/#organization` },
+        },
+      ],
     };
 
     const script = document.createElement('script');

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,3 +8,4 @@ export { default as Navbar } from './Navbar';
 export { default as ScrollToTopButton } from './ScrollToTopButton';
 export { default as StructuredData } from './StructuredData';
 export { default as PhoneIcon } from './PhoneIcon';
+export { default as SEO } from './SEO';

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,9 +1,14 @@
 import { Link } from 'react-router-dom';
-import { MotionSection } from '../components';
+import { MotionSection, SEO } from '../components';
 
 export default function About() {
   return (
     <MotionSection className="relative container space-y-8 py-8">
+      <SEO
+        title="About Keystone Notary Group | Professional Mobile Notaries"
+        description="Learn about Keystone Notary Group, our mission, and the services we provide across the Greater Philadelphia area."
+        path="/about"
+      />
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0 opacity-20 [background:radial-gradient(circle_at_center,_rgba(255,255,255,0.05),_transparent)]"

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { MotionSection } from '../components';
+import { MotionSection, SEO } from '../components';
 
 export default function Contact() {
   const [submitted, setSubmitted] = useState(false);
@@ -73,6 +73,11 @@ export default function Contact() {
   if (submitted) {
     return (
       <MotionSection className="container space-y-6 py-20">
+        <SEO
+          title="Contact Keystone Notary Group | Schedule a Notary"
+          description="Request a mobile notary appointment or ask questions through our contact form."
+          path="/contact"
+        />
         <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
           Thank You
         </h1>
@@ -83,6 +88,11 @@ export default function Contact() {
 
   return (
     <MotionSection id="contact" className="container space-y-8 py-8">
+      <SEO
+        title="Contact Keystone Notary Group | Schedule a Notary"
+        description="Request a mobile notary appointment or ask questions through our contact form."
+        path="/contact"
+      />
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Contact Us
       </h1>

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { MotionSection } from '../components';
+import { MotionSection, SEO } from '../components';
 
 const faqs = [
   {
@@ -38,6 +38,11 @@ export default function FAQ() {
 
   return (
     <MotionSection className="container space-y-8 py-8">
+      <SEO
+        title="Notary FAQs | Keystone Notary Group"
+        description="Answers to common questions about our mobile notary services and scheduling."
+        path="/faq"
+      />
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Frequently Asked Questions
       </h1>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,8 +1,13 @@
-import { Hero, Credentials, MotionSection } from '../components';
+import { Hero, Credentials, MotionSection, SEO } from '../components';
 
 export default function Home() {
   return (
     <>
+      <SEO
+        title="Keystone Notary Group | Mobile Notary Services in Philadelphia"
+        description="Professional mobile notary services serving Philadelphia and surrounding counties."
+        path="/"
+      />
       <Hero />
       <MotionSection className="container space-y-8">
         <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">Why Choose Us?</h2>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,9 +1,13 @@
 import { Link } from 'react-router-dom';
-import { MotionSection } from '../components';
+import { MotionSection, SEO } from '../components';
 
 export default function NotFound() {
   return (
     <MotionSection className="container flex min-h-screen flex-col items-center justify-center space-y-6 text-center">
+      <SEO
+        title="Page Not Found | Keystone Notary Group"
+        description="Sorry, the page you are looking for does not exist."
+      />
       <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
       <p className="text-lg text-platinum">Page not found.</p>
       <Link to="/" className="cta-button hover:border-silver hover:text-silver px-6">

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,4 +1,4 @@
-import { MotionSection } from '../components';
+import { MotionSection, SEO } from '../components';
 
 export default function Services() {
   const services = [
@@ -30,6 +30,11 @@ export default function Services() {
 
   return (
     <MotionSection className="container space-y-8">
+      <SEO
+        title="Notary Services | Keystone Notary Group"
+        description="Explore our full range of notary services including loan signings, apostilles, and more."
+        path="/services"
+      />
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Services
       </h1>


### PR DESCRIPTION
## Summary
- add SEO component to manage per-page meta tags, canonical links, and JSON‑LD page data
- enrich global structured data with Organization and WebSite info
- include SEO component in all pages
- link `robots.txt` and `sitemap.xml` in `index.html`
- test structured data and new SEO component

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686b0bb3871c8327803197612df34da9