### PR TITLE
Add scroll button and icon tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ npm run preview
 
 ## Tests
 
-Run the full test suite with [Vitest](https://vitest.dev/):
+Run tests in watch mode during development:
+
+```bash
+npm test
+```
+
+For a single run with [Vitest](https://vitest.dev/):
 
 ```bash
 npx vitest run

--- a/src/__tests__/CheckIcon.test.jsx
+++ b/src/__tests__/CheckIcon.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import CheckIcon from '../components/CheckIcon';
+
+test('renders check icon svg', () => {
+  const { container } = render(<CheckIcon />);
+  expect(container.querySelector('svg')).toBeInTheDocument();
+});

--- a/src/__tests__/PhoneIcon.test.jsx
+++ b/src/__tests__/PhoneIcon.test.jsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react';
+import PhoneIcon from '../components/PhoneIcon';
+
+test('renders phone icon svg', () => {
+  const { container } = render(<PhoneIcon />);
+  expect(container.querySelector('svg')).toBeInTheDocument();
+});

--- a/src/__tests__/ScrollToTopButton.test.jsx
+++ b/src/__tests__/ScrollToTopButton.test.jsx
@@ -1,0 +1,19 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ScrollToTopButton from '../components/ScrollToTopButton';
+
+// The button should appear once the user has scrolled down the page
+it('shows scroll-to-top button after scrolling', () => {
+  render(<ScrollToTopButton />);
+  // Initially hidden
+  expect(
+    screen.queryByRole('button', { name: /scroll to top/i }),
+  ).not.toBeInTheDocument();
+
+  // Simulate scrolling past the threshold
+  window.scrollY = 400;
+  fireEvent.scroll(window);
+
+  expect(
+    screen.getByRole('button', { name: /scroll to top/i }),
+  ).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add ScrollToTopButton visibility test
- add basic presence tests for PhoneIcon and CheckIcon
- document watch mode and single-run test commands

## Testing
- `npm test --silent`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_686b547339d48327ac7e7cf123a85288