### PR TITLE
Add React-driven 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,17 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Keystone Notary Group, LLC</title>
-    <meta name="description" content="Professional mobile notary services." />
-    <meta property="og:title" content="Keystone Notary Group, LLC" />
-    <meta property="og:description" content="Professional mobile notary services." />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.keystonenotarygroup.com" />
-    <meta property="og:image" content="/logo.svg" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Keystone Notary Group, LLC" />
-    <meta name="twitter:description" content="Professional mobile notary services." />
-    <meta name="twitter:image" content="/logo.svg" />
+    <title>Page Not Found | Keystone Notary Group</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&family=Playfair+Display:wght@500;600&display=swap"
@@ -23,6 +13,6 @@
   </head>
   <body class="min-h-screen font-sans bg-[#121212] text-platinum">
     <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/404.jsx"></script>
   </body>
 </html>

--- a/src/404.jsx
+++ b/src/404.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import NotFound from './pages/NotFound';
+import './index.css';
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <NotFound />
+    </BrowserRouter>
+  </React.StrictMode>
+);
+

--- a/src/__tests__/NotFound.test.jsx
+++ b/src/__tests__/NotFound.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import NotFound from '../pages/NotFound';
+
+test('renders not found message and link to home', () => {
+  render(
+    <MemoryRouter>
+      <NotFound />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('heading', { name: /404/i })).toBeInTheDocument();
+  const link = screen.getByRole('link', { name: /back to home/i });
+  expect(link).toHaveAttribute('href', '/');
+});


### PR DESCRIPTION
## Summary
- mount `NotFound` component via a dedicated React entry point
- wire new entry from `404.html`
- test NotFound page rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686b57c387348327b1b460bebb6cab80