### PR TITLE
Fix credentials layout with pseudo underline

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -6,25 +6,17 @@ exports[`desktop layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative mb-2"
+    class="relative mb-4 pb-2 flex items-center justify-between w-full before:absolute before:bottom-0 before:left-0 before:right-0 before:h-px before:bg-gray-700 before:content-['']"
   >
-    <div
-      class="relative z-10 flex w-full items-end justify-between gap-4"
+    <h2
+      class="text-3xl font-serif font-semibold tracking-wide text-silver"
     >
-      <h2
-        class="text-3xl font-serif font-semibold tracking-wide text-silver"
-      >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="shrink-0 w-20 sm:w-24 md:w-28 lg:w-32"
-        src="/nna-badge.png"
-      />
-    </div>
-    <hr
-      aria-hidden="true"
-      class="absolute inset-x-0 bottom-0 border-0 border-b border-gray-600"
+      Credentials
+    </h2>
+    <img
+      alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="w-24 sm:w-28 lg:w-32 shrink-0 z-10"
+      src="/nna-badge.png"
     />
   </div>
   <ul
@@ -103,25 +95,17 @@ exports[`mobile landscape layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative mb-2"
+    class="relative mb-4 pb-2 flex items-center justify-between w-full before:absolute before:bottom-0 before:left-0 before:right-0 before:h-px before:bg-gray-700 before:content-['']"
   >
-    <div
-      class="relative z-10 flex w-full items-end justify-between gap-4"
+    <h2
+      class="text-3xl font-serif font-semibold tracking-wide text-silver"
     >
-      <h2
-        class="text-3xl font-serif font-semibold tracking-wide text-silver"
-      >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="shrink-0 w-20 sm:w-24 md:w-28 lg:w-32"
-        src="/nna-badge.png"
-      />
-    </div>
-    <hr
-      aria-hidden="true"
-      class="absolute inset-x-0 bottom-0 border-0 border-b border-gray-600"
+      Credentials
+    </h2>
+    <img
+      alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="w-24 sm:w-28 lg:w-32 shrink-0 z-10"
+      src="/nna-badge.png"
     />
   </div>
   <ul
@@ -200,25 +184,17 @@ exports[`mobile portrait layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative mb-2"
+    class="relative mb-4 pb-2 flex items-center justify-between w-full before:absolute before:bottom-0 before:left-0 before:right-0 before:h-px before:bg-gray-700 before:content-['']"
   >
-    <div
-      class="relative z-10 flex w-full items-end justify-between gap-4"
+    <h2
+      class="text-3xl font-serif font-semibold tracking-wide text-silver"
     >
-      <h2
-        class="text-3xl font-serif font-semibold tracking-wide text-silver"
-      >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="shrink-0 w-20 sm:w-24 md:w-28 lg:w-32"
-        src="/nna-badge.png"
-      />
-    </div>
-    <hr
-      aria-hidden="true"
-      class="absolute inset-x-0 bottom-0 border-0 border-b border-gray-600"
+      Credentials
+    </h2>
+    <img
+      alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="w-24 sm:w-28 lg:w-32 shrink-0 z-10"
+      src="/nna-badge.png"
     />
   </div>
   <ul

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -10,22 +10,15 @@ export default function Credentials() {
 
   return (
     <MotionSection className="container space-y-6">
-      {/* Heading and badge aligned in a single row with line behind */}
-      <div className="relative mb-2">
-        <div className="relative z-10 flex w-full items-end justify-between gap-4">
-          <h2 className="text-3xl font-serif font-semibold tracking-wide text-silver">
-            Credentials
-          </h2>
-          <img
-            src="/nna-badge.png"
-            alt="Certified NNA Notary Signing Agent 2025 badge"
-            className="shrink-0 w-20 sm:w-24 md:w-28 lg:w-32"
-          />
-        </div>
-        {/* Full-width line positioned behind the heading and badge */}
-        <hr
-          aria-hidden="true"
-          className="absolute inset-x-0 bottom-0 border-0 border-b border-gray-600"
+      {/* Heading and badge inline with decorative line behind */}
+      <div
+        className="relative mb-4 pb-2 flex items-center justify-between w-full before:absolute before:bottom-0 before:left-0 before:right-0 before:h-px before:bg-gray-700 before:content-['']"
+      >
+        <h2 className="text-3xl font-serif font-semibold tracking-wide text-silver">Credentials</h2>
+        <img
+          src="/nna-badge.png"
+          alt="Certified NNA Notary Signing Agent 2025 badge"
+          className="w-24 sm:w-28 lg:w-32 shrink-0 z-10"
         />
       </div>
       <ul className="space-y-4">


### PR DESCRIPTION
## Summary
- align credentials heading and NNA badge in a single flex row
- add decorative underline using pseudo-element
- update snapshots

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686baf61ed78832780faed83658e28d4