### PR TITLE
Add non-watch test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Run tests in watch mode during development:
 npm test
 ```
 
-For a single run with [Vitest](https://vitest.dev/):
+For CI pipelines or one-off runs, use the script below to avoid hanging watch mode:
 
 ```bash
-npx vitest run
+npm run test:run
 ```
 
 ## Static Hosting

--- a/TODO.md
+++ b/TODO.md
@@ -45,6 +45,7 @@ This file outlines features, improvements, and implementation tasks for Codex to
 - [ ] Configure automatic sitemap and robots.txt generation.
 - [ ] Implement client-side routing fallback for deeper links if needed.
 - [x] Update README with testing instructions for Vitest.
+- [x] Add `test:run` script for non-watch test execution.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build && cp dist/sitemap.xml public/sitemap.xml",
     "preview": "vite preview",
-    "test": "vitest --watch"
+    "test": "vitest --watch",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "framer-motion": "^11.0.0",


### PR DESCRIPTION
## Summary
- add `test:run` script for vitest
- document the new script in README
- mark TODO item for new test script

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_b_686be58e0a748327ab8d8e96d7b9394f