### PR TITLE
Add CTA link on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,6 +12,16 @@
     <script defer data-domain="keystonenotarygroup.com" src="https://plausible.io/js/plausible.js"></script>
   </head>
   <body class="min-h-screen font-sans bg-[#121212] text-platinum">
+    <noscript>
+      <div class="container flex min-h-screen flex-col items-center justify-center gap-4 text-center py-8">
+        <h1 class="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
+        <p class="text-lg">Page not found.</p>
+        <div class="flex flex-col items-center gap-4 sm:flex-row">
+          <a href="/contact#contact" class="cta-button hover:border-silver hover:text-silver px-6">Schedule Appointment</a>
+          <a href="/" class="cta-button hover:border-silver hover:text-silver px-6">Back to Home</a>
+        </div>
+      </div>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/404.jsx"></script>
   </body>

--- a/src/__tests__/NotFound.test.jsx
+++ b/src/__tests__/NotFound.test.jsx
@@ -2,13 +2,15 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import NotFound from '../pages/NotFound';
 
-test('renders not found message and link to home', () => {
+test('renders not found message and navigation links', () => {
   render(
     <MemoryRouter>
       <NotFound />
     </MemoryRouter>
   );
   expect(screen.getByRole('heading', { name: /404/i })).toBeInTheDocument();
-  const link = screen.getByRole('link', { name: /back to home/i });
-  expect(link).toHaveAttribute('href', '/');
+  const scheduleLink = screen.getByRole('link', { name: /schedule appointment/i });
+  expect(scheduleLink).toHaveAttribute('href', '/contact#contact');
+  const homeLink = screen.getByRole('link', { name: /back to home/i });
+  expect(homeLink).toHaveAttribute('href', '/');
 });

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -10,9 +10,20 @@ export default function NotFound() {
       />
       <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
       <p className="text-lg text-platinum">Page not found.</p>
-      <Link to="/" className="cta-button hover:border-silver hover:text-silver px-6">
-        Back to Home
-      </Link>
+      <div className="flex flex-col items-center gap-4 sm:flex-row">
+        <Link
+          to="/contact#contact"
+          className="cta-button hover:border-silver hover:text-silver px-6"
+        >
+          Schedule Appointment
+        </Link>
+        <Link
+          to="/"
+          className="cta-button hover:border-silver hover:text-silver px-6"
+        >
+          Back to Home
+        </Link>
+      </div>
     </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- add "Schedule Appointment" call-to-action on the NotFound page
- include same fallback markup in `404.html`
- update unit test for new link

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_b_686be656e4b883279868e3c6389fe0e1