### PR TITLE
Adjust hero heading for short landscape views

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -17,7 +17,7 @@ export default function Hero() {
         transition={{ duration: 0.8 }}
         className="container relative z-10 flex flex-col items-center space-y-8 px-4 lg:space-y-10"
       >
-        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient lg:text-6xl">
+        <h1 className="hero-heading text-4xl font-serif font-semibold tracking-wide heading-gradient lg:text-6xl">
           Keystone Notary Group, LLC
         </h1>
         <p className="text-lg font-light lg:text-2xl">Reliable Mobile Notary Services</p>

--- a/src/index.css
+++ b/src/index.css
@@ -31,4 +31,10 @@
   .cta-button {
     @apply inline-block rounded border border-platinum bg-deepgray px-8 py-3 text-lg font-medium text-white transition-colors;
   }
+
+  @media (orientation: landscape) and (max-height: 500px) {
+    .hero-heading {
+      @apply text-3xl;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- shrink hero heading in landscape screens under 500px tall
- apply `.hero-heading` class to the Hero component

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_686bec590c148327a2c599f71120bc82