### PR TITLE
Fix Credentials layout overlapping badge

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -6,15 +6,16 @@ exports[`desktop layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="credentials-container"
+    class="relative inline-flex w-full flex-wrap items-end gap-4 bg-black pb-4 mb-6 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700 after:z-0"
   >
     <h2
-      class="credentials-heading text-3xl font-serif font-semibold tracking-wide text-silver flex-grow"
+      class="credentials-heading relative z-10 text-3xl font-serif font-semibold tracking-wide text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="relative z-10 h-14 -mb-6 flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -94,15 +95,16 @@ exports[`mobile landscape layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="credentials-container"
+    class="relative inline-flex w-full flex-wrap items-end gap-4 bg-black pb-4 mb-6 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700 after:z-0"
   >
     <h2
-      class="credentials-heading text-3xl font-serif font-semibold tracking-wide text-silver flex-grow"
+      class="credentials-heading relative z-10 text-3xl font-serif font-semibold tracking-wide text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="relative z-10 h-14 -mb-6 flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -182,15 +184,16 @@ exports[`mobile portrait layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="credentials-container"
+    class="relative inline-flex w-full flex-wrap items-end gap-4 bg-black pb-4 mb-6 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700 after:z-0"
   >
     <h2
-      class="credentials-heading text-3xl font-serif font-semibold tracking-wide text-silver flex-grow"
+      class="credentials-heading relative z-10 text-3xl font-serif font-semibold tracking-wide text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="relative z-10 h-14 -mb-6 flex-none"
       src="/nna-badge.png"
     />
   </div>

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -10,14 +10,14 @@ export default function Credentials() {
 
   return (
     <MotionSection className="container space-y-6 text-center md:text-left">
-      {/* Heading and badge with line that spans full width */}
-      <div className="credentials-container">
-        <h2 className="credentials-heading text-3xl font-serif font-semibold tracking-wide text-silver flex-grow">
+      <div className="relative inline-flex w-full flex-wrap items-end gap-4 bg-black pb-4 mb-6 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700 after:z-0">
+        <h2 className="credentials-heading relative z-10 text-3xl font-serif font-semibold tracking-wide text-silver">
           Credentials
         </h2>
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
+          className="relative z-10 h-14 -mb-6 flex-none"
         />
       </div>
       <ul className="space-y-4">

--- a/src/index.css
+++ b/src/index.css
@@ -32,18 +32,6 @@
     @apply inline-block rounded border border-platinum bg-deepgray px-8 py-3 text-lg font-medium text-white transition-colors;
   }
 
-  .credentials-container {
-    @apply relative flex flex-wrap items-center justify-center gap-4 pb-4 mb-6 md:justify-start;
-  }
-  .credentials-container::after {
-    content: '';
-    @apply absolute bottom-0 left-0 w-full border-b border-gray-700;
-    z-index: 0;
-  }
-
-  .credentials-container img {
-    @apply relative z-10 flex-none -mb-6 translate-y-[10%];
-  }
 
   @media (orientation: landscape) and (max-height: 500px) {
     .hero-heading {


### PR DESCRIPTION
## Summary
- use a single flex container for heading and badge
- rely on Tailwind utilities instead of custom classes
- update CSS and snapshots

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_b_686c08bc23a0832798ebe53793c73da1