### PR TITLE
Fix Credentials badge layout

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -6,16 +6,16 @@ exports[`320px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative inline-flex flex-wrap items-end gap-4 pb-4 mb-6 bg-black after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700"
+    class="relative mb-6 flex items-center justify-center gap-4 pb-4 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700/60 md:justify-start"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-14 -mb-6 flex-none"
+      class="h-[5rem] w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -40,79 +40,52 @@ exports[`320px layout matches snapshot 1`] = `
       <span
         class="text-platinum"
       >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="mt-4 sm:mt-0 w-16 sm:w-20"
-        src="/nna-badge.png"
-      />
-    </div>
-    <div
-      class="my-4 h-px bg-gray-700"
-    />
-    <ul
-      class="space-y-4 pl-1"
+        Licensed & Bonded
+      </span>
+    </li>
+    <li
+      class="flex items-start"
     >
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Licensed & Bonded
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Certified Signing Agent
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+        Certified Signing Agent
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Member of National Notary Association
-        </span>
-      </li>
-    </ul>
-  </div>
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Member of National Notary Association
+      </span>
+    </li>
+  </ul>
 </section>
 `;
 
@@ -122,16 +95,16 @@ exports[`640px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative inline-flex flex-wrap items-end gap-4 pb-4 mb-6 bg-black after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700"
+    class="relative mb-6 flex items-center justify-center gap-4 pb-4 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700/60 md:justify-start"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-14 -mb-6 flex-none"
+      class="h-[5rem] w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -156,79 +129,52 @@ exports[`640px layout matches snapshot 1`] = `
       <span
         class="text-platinum"
       >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="mt-4 sm:mt-0 w-16 sm:w-20"
-        src="/nna-badge.png"
-      />
-    </div>
-    <div
-      class="my-4 h-px bg-gray-700"
-    />
-    <ul
-      class="space-y-4 pl-1"
+        Licensed & Bonded
+      </span>
+    </li>
+    <li
+      class="flex items-start"
     >
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Licensed & Bonded
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Certified Signing Agent
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
+        Certified Signing Agent
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
       >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Member of National Notary Association
-        </span>
-      </li>
-    </ul>
-  </div>
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Member of National Notary Association
+      </span>
+    </li>
+  </ul>
 </section>
 `;
 
@@ -238,169 +184,174 @@ exports[`1024px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="relative inline-flex flex-wrap items-end gap-4 pb-4 mb-6 bg-black after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700"
+    class="relative mb-6 flex items-center justify-center gap-4 pb-4 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700/60 md:justify-start"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-14 -mb-6 flex-none"
+      class="h-[5rem] w-auto flex-none"
       src="/nna-badge.png"
-     />   
-    <ul
-      class="space-y-4 pl-1"
-    >
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Licensed & Bonded
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Certified Signing Agent
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Member of National Notary Association
-        </span>
-      </li>
-    </ul>
+    />
   </div>
+  <ul
+    class="space-y-4"
+  >
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Licensed & Bonded
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Certified Signing Agent
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Member of National Notary Association
+      </span>
+    </li>
+  </ul>
 </section>
 `;
 
 exports[`1280px layout matches snapshot 1`] = `
 <section
-  class="container px-4"
+  class="container space-y-6 text-center md:text-left"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="max-w-3xl mx-auto w-full"
+    class="relative mb-6 flex items-center justify-center gap-4 pb-4 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700/60 md:justify-start"
   >
-    <div
-      class="flex flex-col sm:flex-row sm:items-center sm:justify-between"
+    <h2
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
-      <h2
-        class="text-3xl font-serif font-semibold tracking-wide text-silver"
-      >
-        Credentials
-      </h2>
-      <img
-        alt="Certified NNA Notary Signing Agent 2025 badge"
-        class="mt-4 sm:mt-0 w-16 sm:w-20"
-        src="/nna-badge.png"
-      />
-    </div>
-    <div
-      class="my-4 h-px bg-gray-700"
+      Credentials
+    </h2>
+    <img
+      alt="Certified NNA Notary Signing Agent 2025 badge"
+      class="h-[5rem] w-auto flex-none"
+      src="/nna-badge.png"
     />
-    <ul
-      class="space-y-4 pl-1"
-    >
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Licensed & Bonded
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Certified Signing Agent
-        </span>
-      </li>
-      <li
-        class="flex items-start text-platinum text-lg sm:text-xl"
-      >
-        <svg
-          aria-hidden="true"
-          class="h-5 w-5 mt-1 mr-2 text-silver"
-          fill="currentColor"
-          viewBox="0 0 20 20"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
-            fill-rule="evenodd"
-          />
-        </svg>
-        <span>
-          Member of National Notary Association
-        </span>
-      </li>
-    </ul>
   </div>
+  <ul
+    class="space-y-4"
+  >
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Licensed & Bonded
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Certified Signing Agent
+      </span>
+    </li>
+    <li
+      class="flex items-start"
+    >
+      <svg
+        aria-hidden="true"
+        class="mr-2 h-5 w-5 text-silver"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          clip-rule="evenodd"
+          d="M16.707 5.293a1 1 0 010 1.414L8.414 15l-4.121-4.121a1 1 0 011.414-1.414L8.414 12.586l7.293-7.293a1 1 0 011.414 0z"
+          fill-rule="evenodd"
+        />
+      </svg>
+      <span
+        class="text-platinum"
+      >
+        Member of National Notary Association
+      </span>
+    </li>
+  </ul>
 </section>
 `;

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -9,16 +9,15 @@ export default function Credentials() {
   ];
 
   return (
-
     <MotionSection className="container space-y-6 text-center md:text-left">
-      <div className="relative inline-flex flex-wrap items-end gap-4 pb-4 mb-6 bg-black after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700">
-        <h2 className="text-3xl font-serif font-semibold tracking-wide text-silver">
+      <div className="relative mb-6 flex items-center justify-center gap-4 pb-4 after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-gray-700/60 md:justify-start">
+        <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
           Credentials
         </h2>
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="h-14 -mb-6 flex-none"
+          className="h-[5rem] w-auto flex-none"
         />
       </div>
 
@@ -33,3 +32,4 @@ export default function Credentials() {
     </MotionSection>
   );
 }
+


### PR DESCRIPTION
## Summary
- ensure Credentials heading and badge align on one row with divider behind
- enlarge the badge ~40% for visibility
- restore text-center alignment on small screens
- update snapshots

## Testing
- `npm run test:run -- -u`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686ccfddc9588327a405cefe67d1b02f