### PR TITLE
Fix landscape layout of Credentials

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -2,11 +2,11 @@
 
 exports[`320px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8"
+  class="container space-y-6 py-8 text-center"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4 md:justify-start"
+    class="flex items-center justify-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -23,7 +23,7 @@ exports[`320px layout matches snapshot 1`] = `
     class="space-y-4"
   >
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -44,7 +44,7 @@ exports[`320px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -65,7 +65,7 @@ exports[`320px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -91,11 +91,11 @@ exports[`320px layout matches snapshot 1`] = `
 
 exports[`640px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8"
+  class="container space-y-6 py-8 text-center"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4 md:justify-start"
+    class="flex items-center justify-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -112,7 +112,7 @@ exports[`640px layout matches snapshot 1`] = `
     class="space-y-4"
   >
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -133,7 +133,7 @@ exports[`640px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -154,7 +154,7 @@ exports[`640px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -180,11 +180,11 @@ exports[`640px layout matches snapshot 1`] = `
 
 exports[`1024px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8"
+  class="container space-y-6 py-8 text-center"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4 md:justify-start"
+    class="flex items-center justify-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -201,7 +201,7 @@ exports[`1024px layout matches snapshot 1`] = `
     class="space-y-4"
   >
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -222,7 +222,7 @@ exports[`1024px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -243,7 +243,7 @@ exports[`1024px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -269,11 +269,11 @@ exports[`1024px layout matches snapshot 1`] = `
 
 exports[`1280px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8"
+  class="container space-y-6 py-8 text-center"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4 md:justify-start"
+    class="flex items-center justify-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -290,7 +290,7 @@ exports[`1280px layout matches snapshot 1`] = `
     class="space-y-4"
   >
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -311,7 +311,7 @@ exports[`1280px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"
@@ -332,7 +332,7 @@ exports[`1280px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start"
+      class="flex items-start justify-center"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -9,8 +9,8 @@ export default function Credentials() {
   ];
 
   return (
-    <MotionSection className="container space-y-6 py-8">
-      <div className="flex items-center justify-center gap-4 md:justify-start">
+    <MotionSection className="container space-y-6 py-8 text-center">
+      <div className="flex items-center justify-center gap-4">
         <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
           Credentials
         </h2>
@@ -23,11 +23,10 @@ export default function Credentials() {
 
       <ul className="space-y-4">
         {credentials.map((cred) => (
-          <li key={cred} className="flex items-start">
+          <li key={cred} className="flex items-start justify-center">
             <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
             <span className="text-platinum">{cred}</span>
           </li>
         ))}
       </ul>
-    </MotionSection>
-  );}
+    </MotionSection>  );}

--- a/src/index.css
+++ b/src/index.css
@@ -37,9 +37,6 @@
     .hero-heading {
       @apply text-3xl;
     }
-    .credentials-heading {
-      @apply text-2xl;
-    }
     .why-heading {
       @apply text-2xl;
     }


### PR DESCRIPTION
## Summary
- center the Credentials section and list items
- remove unused CSS class for landscape orientation
- update snapshots

## Testing
- `npm run test:run --silent`
- `npm run build --silent`
- `npm run preview --silent -- --port 4173` *(fails: Unknown option `-p`)*

------
https://chatgpt.com/codex/tasks/task_b_686d54abc5dc8327a9549cf66327a53d