### PR TITLE
Fix Credentials heading alignment

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -2,11 +2,11 @@
 
 exports[`320px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  class="container space-y-6 py-8"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -91,11 +91,11 @@ exports[`320px layout matches snapshot 1`] = `
 
 exports[`640px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  class="container space-y-6 py-8"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -180,11 +180,11 @@ exports[`640px layout matches snapshot 1`] = `
 
 exports[`1024px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  class="container space-y-6 py-8"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
@@ -269,11 +269,11 @@ exports[`1024px layout matches snapshot 1`] = `
 
 exports[`1280px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  class="container space-y-6 py-8"
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
       class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -9,8 +9,8 @@ export default function Credentials() {
   ];
 
   return (
-    <MotionSection className="container space-y-6 py-8 text-center">
-      <div className="flex items-center justify-center gap-4">
+    <MotionSection className="container space-y-6 py-8">
+      <div className="flex items-center gap-4">
         <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
           Credentials
         </h2>
@@ -29,4 +29,6 @@ export default function Credentials() {
           </li>
         ))}
       </ul>
-    </MotionSection>  );}
+    </MotionSection>
+  );
+}


### PR DESCRIPTION
## Summary
- left-align Credentials heading so decorative line matches other sections
- update snapshots

## Testing
- `npm run test:run -- -u`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686d6f2dd9f88327b07f14f5d1c02978