### PR TITLE
Fix credentials divider alignment

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -6,10 +6,10 @@ exports[`320px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
@@ -95,10 +95,10 @@ exports[`640px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
@@ -184,10 +184,10 @@ exports[`1024px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>
@@ -273,10 +273,10 @@ exports[`1280px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center justify-center gap-4"
+    class="flex items-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
     >
       Credentials
     </h2>

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -10,8 +10,9 @@ export default function Credentials() {
 
   return (
     <MotionSection className="container space-y-6 py-8 text-center">
-      <div className="flex items-center justify-center gap-4">
-        <h2 className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+      <div className="flex items-center gap-4">
+        {/* align divider to left edge like 'Why Choose Us?' heading */}
+        <h2 className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
           Credentials
         </h2>
         <img
@@ -29,4 +30,6 @@ export default function Credentials() {
           </li>
         ))}
       </ul>
-    </MotionSection>  );}
+    </MotionSection>
+  );
+}


### PR DESCRIPTION
## Summary
- adjust Credentials heading layout so underline aligns left with text
- update snapshots

## Testing
- `yarn test:run -u`
- `yarn build`
- `yarn preview` (fails due to no browser in CI)

------
https://chatgpt.com/codex/tasks/task_b_686d7b1ba38083278403f74b072199c9