### PR TITLE
Improve home section spacing

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -2,7 +2,8 @@
 
 exports[`320px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  aria-labelledby="credentials-heading"
+  class="container mt-12 border-t border-deepgray py-8 text-center space-y-6 "
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
@@ -10,6 +11,7 @@ exports[`320px layout matches snapshot 1`] = `
   >
     <h2
       class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      id="credentials-heading"
     >
       Credentials
     </h2>
@@ -91,7 +93,8 @@ exports[`320px layout matches snapshot 1`] = `
 
 exports[`640px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  aria-labelledby="credentials-heading"
+  class="container mt-12 border-t border-deepgray py-8 text-center space-y-6 "
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
@@ -99,6 +102,7 @@ exports[`640px layout matches snapshot 1`] = `
   >
     <h2
       class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      id="credentials-heading"
     >
       Credentials
     </h2>
@@ -180,7 +184,8 @@ exports[`640px layout matches snapshot 1`] = `
 
 exports[`1024px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  aria-labelledby="credentials-heading"
+  class="container mt-12 border-t border-deepgray py-8 text-center space-y-6 "
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
@@ -188,6 +193,7 @@ exports[`1024px layout matches snapshot 1`] = `
   >
     <h2
       class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      id="credentials-heading"
     >
       Credentials
     </h2>
@@ -269,7 +275,8 @@ exports[`1024px layout matches snapshot 1`] = `
 
 exports[`1280px layout matches snapshot 1`] = `
 <section
-  class="container space-y-6 py-8 text-center"
+  aria-labelledby="credentials-heading"
+  class="container mt-12 border-t border-deepgray py-8 text-center space-y-6 "
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
@@ -277,6 +284,7 @@ exports[`1280px layout matches snapshot 1`] = `
   >
     <h2
       class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      id="credentials-heading"
     >
       Credentials
     </h2>

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -1,7 +1,8 @@
 import CheckIcon from './CheckIcon';
 import MotionSection from './MotionSection';
 
-export default function Credentials() {
+// Provide optional className for additional layout control
+export default function Credentials({ className = '' }) {
   const credentials = [
     'Licensed & Bonded',
     'Certified Signing Agent',
@@ -9,10 +10,17 @@ export default function Credentials() {
   ];
 
   return (
-    <MotionSection className="container space-y-6 py-8 text-center">
+    // Top margin and border create clear division from prior section
+    <MotionSection
+      aria-labelledby="credentials-heading"
+      className={`container mt-12 border-t border-deepgray py-8 text-center space-y-6 ${className}`}
+    >
       <div className="flex items-center gap-4">
         {/* align divider to left edge like 'Why Choose Us?' heading */}
-        <h2 className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        <h2
+          id="credentials-heading"
+          className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+        >
           Credentials
         </h2>
         <img

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -10,8 +10,15 @@ export default function Home() {
       />
       <Hero />
 
-      <MotionSection className="container space-y-6 text-center py-8">
-        <h2 className="why-heading text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+      {/* Separate section with explicit landmarks for accessibility */}
+      <MotionSection
+        aria-labelledby="why-heading"
+        className="container space-y-6 py-8 text-center"
+      >
+        <h2
+          id="why-heading"
+          className="why-heading text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+        >
           Why Choose Us?
         </h2>
         <p className="text-lg text-platinum">
@@ -20,6 +27,6 @@ export default function Home() {
         </p>
       </MotionSection>
 
+      {/* Apply margin and border to visually separate from the text above */}
       <Credentials />
-    </>
-  );}
+    </>  );}


### PR DESCRIPTION
## Summary
- clarify `Home` landmarks and ensure sections have IDs
- enhance `Credentials` spacing and ARIA
- update snapshots

## Testing
- `npm run test:run`
- `npm run build`
- `npm run preview` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_b_686d9ec01fbc83278253f001e5d72b6a