### PR TITLE
Align credentials list with heading

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -22,10 +22,10 @@ exports[`320px layout matches snapshot 1`] = `
     />
   </div>
   <ul
-    class="space-y-4"
+    class="mx-auto w-max space-y-4 text-left"
   >
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -46,7 +46,7 @@ exports[`320px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -67,7 +67,7 @@ exports[`320px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -113,10 +113,10 @@ exports[`640px layout matches snapshot 1`] = `
     />
   </div>
   <ul
-    class="space-y-4"
+    class="mx-auto w-max space-y-4 text-left"
   >
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -137,7 +137,7 @@ exports[`640px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -158,7 +158,7 @@ exports[`640px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -204,10 +204,10 @@ exports[`1024px layout matches snapshot 1`] = `
     />
   </div>
   <ul
-    class="space-y-4"
+    class="mx-auto w-max space-y-4 text-left"
   >
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -228,7 +228,7 @@ exports[`1024px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -249,7 +249,7 @@ exports[`1024px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -295,10 +295,10 @@ exports[`1280px layout matches snapshot 1`] = `
     />
   </div>
   <ul
-    class="space-y-4"
+    class="mx-auto w-max space-y-4 text-left"
   >
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -319,7 +319,7 @@ exports[`1280px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"
@@ -340,7 +340,7 @@ exports[`1280px layout matches snapshot 1`] = `
       </span>
     </li>
     <li
-      class="flex items-start justify-center"
+      class="flex items-start justify-start"
     >
       <svg
         aria-hidden="true"

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -30,9 +30,9 @@ export default function Credentials({ className = '' }) {
         />
       </div>
 
-      <ul className="space-y-4">
+      <ul className="mx-auto w-max space-y-4 text-left">
         {credentials.map((cred) => (
-          <li key={cred} className="flex items-start justify-center">
+          <li key={cred} className="flex items-start justify-start">
             <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
             <span className="text-platinum">{cred}</span>
           </li>


### PR DESCRIPTION
## Summary
- align credential check marks under heading
- update credential snapshots

## Testing
- `yarn test:run`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_686dac2bd9408327a6fa6c5a78eeaa78