### PR TITLE
Fix credentials layout and update snapshot

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -7,17 +7,17 @@ exports[`320px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center gap-4"
+    class="flex items-center justify-center gap-4"
   >
     <h2
-      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-16 w-auto flex-none"
+      class="h-20 w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -98,17 +98,17 @@ exports[`640px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center gap-4"
+    class="flex items-center justify-center gap-4"
   >
     <h2
-      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-16 w-auto flex-none"
+      class="h-20 w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -189,17 +189,17 @@ exports[`1024px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center gap-4"
+    class="flex items-center justify-center gap-4"
   >
     <h2
-      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-16 w-auto flex-none"
+      class="h-20 w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>
@@ -280,17 +280,17 @@ exports[`1280px layout matches snapshot 1`] = `
   style="opacity: 0; transform: translateY(20px);"
 >
   <div
-    class="flex items-center gap-4"
+    class="flex items-center justify-center gap-4"
   >
     <h2
-      class="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
     </h2>
     <img
       alt="Certified NNA Notary Signing Agent 2025 badge"
-      class="h-16 w-auto flex-none"
+      class="h-20 w-auto flex-none"
       src="/nna-badge.png"
     />
   </div>

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -15,18 +15,19 @@ export default function Credentials({ className = '' }) {
       aria-labelledby="credentials-heading"
       className={`container mt-12 border-t border-deepgray py-8 text-center space-y-6 ${className}`}
     >
-      <div className="flex items-center gap-4">
-        {/* align divider to left edge like 'Why Choose Us?' heading */}
+      <div className="flex items-center justify-center gap-4">
+        {/* keep heading sizing consistent with other sections */}
         <h2
           id="credentials-heading"
-          className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+          className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
         >
           Credentials
         </h2>
+        {/* display NNA credential badge next to the heading */}
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="h-16 w-auto flex-none"
+          className="h-20 w-auto flex-none"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- align the NNA badge beside Credentials heading
- enlarge the NNA badge
- match Credentials heading styling to other sections
- update snapshot for revised layout

## Testing
- `yarn lint` *(fails: package not found)*
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_686db09cadd4832793cc7e53ee111dd0