### PR TITLE
Fix Credentials heading alignment

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`320px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -101,7 +101,7 @@ exports[`640px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -192,7 +192,7 @@ exports[`1024px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -283,7 +283,7 @@ exports[`1280px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -16,10 +16,13 @@ export default function Credentials({ className = '' }) {
       className={`container mt-12 border-t border-deepgray py-8 text-center space-y-6 ${className}`}
     >
       <div className="flex items-center justify-center gap-4">
-        {/* keep heading sizing consistent with other sections */}
+        {/*
+          Shift heading slightly left so the "C" aligns with the list
+          checkmarks while keeping the badge spacing consistent.
+        */}
         <h2
           id="credentials-heading"
-          className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+          className="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
         >
           Credentials
         </h2>


### PR DESCRIPTION
## Summary
- align Credentials heading over checklist items by nudging it left
- update snapshots

## Testing
- `npm run test:run -- -u`
- `npm run build`
- `npm run preview` *(fails: command terminated after demonstration)*
- `yarn lint` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686db30215cc83279f5f7668234c5b59