### PR TITLE
Align credentials header

### DIFF
--- a/src/__tests__/__snapshots__/Credentials.test.jsx.snap
+++ b/src/__tests__/__snapshots__/Credentials.test.jsx.snap
@@ -10,7 +10,7 @@ exports[`320px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-8 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -101,7 +101,7 @@ exports[`640px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-8 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -192,7 +192,7 @@ exports[`1024px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-8 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials
@@ -283,7 +283,7 @@ exports[`1280px layout matches snapshot 1`] = `
     class="flex items-center justify-center gap-4"
   >
     <h2
-      class="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      class="-ml-8 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
       id="credentials-heading"
     >
       Credentials

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -22,7 +22,12 @@ export default function Credentials({ className = '' }) {
         */}
         <h2
           id="credentials-heading"
-          className="-ml-6 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+          /*
+            Slightly increased negative margin ensures the "C" of
+            Credentials lines up with the leading check marks below
+            while maintaining badge spacing across breakpoints.
+          */
+          className="-ml-8 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
         >
           Credentials
         </h2>


### PR DESCRIPTION
## Summary
- adjust heading margin so the "C" sits above the checklist
- update snapshots

## Testing
- `npm run test:run`
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686db504b29883278bfa66dd2a9b82e4