### PR TITLE
Refactor semantic layout wrappers

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -15,7 +15,7 @@ export default function Credentials({ className = '' }) {
       aria-labelledby="credentials-heading"
       className={`container mt-12 border-t border-deepgray py-8 text-center space-y-6 ${className}`}
     >
-      <div className="flex items-center justify-center gap-4">
+      <header className="flex items-center justify-center gap-4">
         {/*
           Shift heading slightly left so the "C" aligns with the list
           checkmarks while keeping the badge spacing consistent.
@@ -37,7 +37,7 @@ export default function Credentials({ className = '' }) {
           alt="Certified NNA Notary Signing Agent 2025 badge"
           className="h-20 w-auto flex-none"
         />
-      </div>
+      </header>
 
       <ul className="mx-auto w-max space-y-4 text-left">
         {credentials.map((cred) => (

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -99,10 +99,11 @@ export default function Navbar() {
             onClick={closeMenu}
             role="presentation"
           >
-            <div
+            <nav
               ref={menuRef}
-              className="relative h-full p-6"
+              aria-label="Mobile navigation"
               onClick={(e) => e.stopPropagation()}
+              className="relative h-full p-6 mt-8"
             >
               <button
                 className="absolute top-4 right-4 text-platinum"
@@ -112,8 +113,7 @@ export default function Navbar() {
                 ✕
               </button>
               {/* Mobile menu with a solid background behind item gaps */}
-              <nav aria-label="Mobile navigation" className="mt-8">
-                <ul className="space-y-4 bg-black">
+              <ul className="space-y-4 bg-black">
                   {navItems.map((item) => (
                     <li key={item.name}>
                       <NavLink
@@ -128,7 +128,6 @@ export default function Navbar() {
                   ))}
                 </ul>
               </nav>
-            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -105,7 +105,7 @@ export default function Contact() {
         Contact Us
       </h1>
       <form onSubmit={handleSubmit} className="space-y-6" noValidate>
-        <div className="space-y-4">
+        <fieldset className="space-y-4">
           <label className="block" htmlFor="name">
             <span className="mb-1 block text-platinum">Full Name</span>
             <input
@@ -261,7 +261,7 @@ export default function Contact() {
               Enable appointment request above to choose date and time.
             </p>
           )}
-        </div>
+        </fieldset>
         <label className="block" htmlFor="message">
           <span className="mb-1 block text-platinum">Message</span>
           <textarea

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -10,7 +10,7 @@ export default function NotFound() {
       />
       <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
       <p className="text-lg text-platinum">Page not found.</p>
-      <div className="flex flex-col items-center gap-4 sm:flex-row">
+      <nav aria-label="Error options" className="flex flex-col items-center gap-4 sm:flex-row">
         <Link
           to="/contact#contact"
           className="cta-button hover:border-silver hover:text-silver px-6"
@@ -23,7 +23,7 @@ export default function NotFound() {
         >
           Back to Home
         </Link>
-      </div>
+      </nav>
     </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- replace credentials div with header
- switch contact page field container to fieldset
- streamline navbar mobile menu layout
- use semantic nav in 404 page

## Testing
- `yarn lint` *(fails: package missing in lockfile)*
- `yarn test:run` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_686dc3681e708327ad5243739e5c0234