### PR TITLE
Improve mobile menu overlay semantics

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -90,24 +90,19 @@ export default function Navbar() {
       </nav>
       <AnimatePresence>
         {open && (
-          <div
-            className="fixed inset-0 z-40 bg-black md:hidden"
-            role="button"
-            aria-label="Close menu overlay"
-            tabIndex={0}
-            onClick={closeMenu}
-            onKeyDown={(e) => {
-              if (['Escape', 'Enter', ' '].includes(e.key)) {
-                closeMenu();
-              }
-            }}
-          >
+          <div className="relative fixed inset-0 z-40 bg-black md:hidden">
+            <button
+              type="button"
+              aria-label="Close menu overlay"
+              onClick={closeMenu}
+              className="absolute inset-0"
+            />
             {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
             <nav
               ref={menuRef}
               aria-label="Mobile navigation"
               onMouseDown={(e) => e.stopPropagation()}
-              className="relative h-full p-6 mt-8"
+              className="relative h-full mt-8 p-6"
             >
               <button
                 className="absolute top-4 right-4 text-platinum"


### PR DESCRIPTION
## Summary
- ensure overlay element for the mobile menu uses a real button for closing
- keep navigation accessible with onMouseDown handler

## Testing
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `npm run preview`
- `npx axe ./dist/index.html` *(fails: cannot find Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_b_686dd69d3348832788865ff87bfa2098