### PR TITLE
Improve 404 experience

### DIFF
--- a/404.html
+++ b/404.html
@@ -75,12 +75,13 @@
   </head>
   <body class="min-h-screen font-sans bg-[#121212] text-platinum">
     <noscript>
-      <div class="container flex min-h-screen flex-col items-center justify-center gap-4 text-center py-8">
+      <div class="container flex min-h-screen flex-col items-center justify-center gap-4 py-8 text-center">
+        <img src="/logo.svg" alt="Keystone Notary Group logo" class="mx-auto h-16 w-16 text-silver" />
         <h1 class="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
-        <p class="text-lg">Page not found.</p>
+        <p class="text-lg">Sorry, we can’t find that page.</p>
         <div class="flex flex-col items-center gap-4 sm:flex-row">
           <a href="/contact#contact" class="cta-button hover:border-silver hover:text-silver px-6">Schedule Appointment</a>
-          <a href="/" class="cta-button hover:border-silver hover:text-silver px-6">Back to Home</a>
+          <a href="/" class="cta-button hover:border-silver hover:text-silver px-6">Return Home</a>
         </div>
       </div>
     </noscript>

--- a/src/404.jsx
+++ b/src/404.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import NotFound from './pages/NotFound';
-import StructuredData from './components/StructuredData';
+import Layout from './components/Layout';
 import './index.css';
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
-      <StructuredData />
-      <NotFound />
+      <Routes>
+        <Route element={<Layout />}>
+          <Route path="*" element={<NotFound />} />
+        </Route>
+      </Routes>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/__tests__/NotFound.test.jsx
+++ b/src/__tests__/NotFound.test.jsx
@@ -8,9 +8,10 @@ test('renders not found message and navigation links', () => {
       <NotFound />
     </MemoryRouter>
   );
+  expect(screen.getByRole('img', { name: /keystone notary group logo/i })).toBeInTheDocument();
   expect(screen.getByRole('heading', { name: /404/i })).toBeInTheDocument();
   const scheduleLink = screen.getByRole('link', { name: /schedule appointment/i });
   expect(scheduleLink).toHaveAttribute('href', '/contact#contact');
-  const homeLink = screen.getByRole('link', { name: /back to home/i });
+  const homeLink = screen.getByRole('link', { name: /return home/i });
   expect(homeLink).toHaveAttribute('href', '/');
 });

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,25 +3,20 @@ import { MotionSection, SEO } from '../components';
 
 export default function NotFound() {
   return (
-    <MotionSection className="container flex min-h-screen flex-col items-center justify-center gap-6 text-center">
+    <MotionSection className="container flex min-h-screen flex-col items-center justify-center gap-6 py-8 text-center">
       <SEO
         title="Page Not Found | Keystone Notary Group"
         description="Sorry, the page you are looking for does not exist."
       />
+      <img src="/logo.svg" alt="Keystone Notary Group logo" className="mx-auto h-16 w-16 text-silver" />
       <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
-      <p className="text-lg text-platinum">Page not found.</p>
-      <nav aria-label="Error options" className="flex flex-col items-center gap-4 sm:flex-row">
-        <Link
-          to="/contact#contact"
-          className="cta-button hover:border-silver hover:text-silver px-6"
-        >
+      <p className="text-lg text-platinum">Sorry, we can’t find that page.</p>
+      <nav aria-label="Helpful links" className="flex flex-col items-center gap-4 sm:flex-row">
+        <Link to="/contact#contact" className="cta-button hover:border-silver hover:text-silver px-6">
           Schedule Appointment
         </Link>
-        <Link
-          to="/"
-          className="cta-button hover:border-silver hover:text-silver px-6"
-        >
-          Back to Home
+        <Link to="/" className="cta-button hover:border-silver hover:text-silver px-6">
+          Return Home
         </Link>
       </nav>
     </MotionSection>


### PR DESCRIPTION
## Summary
- polish NotFound page visuals and copy
- integrate Layout into 404 entry point
- update fallback HTML for no-JS users
- adjust NotFound test expectations

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview` *(fails: Killed after start)*

------
https://chatgpt.com/codex/tasks/task_b_686de81418008327a9c90ef38a1ad59d