### PR TITLE
Fix divider alignment for home sections

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -44,6 +44,8 @@ export default function Credentials({ className = '' }) {
           height="80"
         />
       </header>
+      {/* match hero divider styling */}
+      <div aria-hidden="true" className="self-start ml-0 h-px w-24 bg-silver" />
 
       <ul className="mx-auto w-max flex flex-col gap-4 text-left">
         {credentials.map((cred) => (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,6 +21,8 @@ export default function Home() {
         >
           Why Choose Us?
         </h2>
+        {/* match hero divider styling */}
+        <div aria-hidden="true" className="self-start ml-0 h-px w-24 bg-silver" />
         <p className="text-lg text-platinum">
           Keystone Notary Group, LLC provides professional, reliable, and
           convenient mobile notary services. We bring the notary public to you.


### PR DESCRIPTION
## Summary
- align horizontal dividers after "Why Choose Us" and Credentials headings with hero divider

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686dfaa6156c832788558be05990a483