### PR TITLE
Fix hero divider alignment

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -44,8 +44,8 @@ export default function Credentials({ className = '' }) {
           height="80"
         />
       </header>
-      {/* match hero divider styling */}
-      <div aria-hidden="true" className="self-start ml-0 h-px w-24 bg-silver" />
+      {/* replicate hero divider beneath heading */}
+      <hr className="w-full border-t border-gray-600 my-4" />
 
       <ul className="mx-auto w-max flex flex-col gap-4 text-left">
         {credentials.map((cred) => (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,8 +21,8 @@ export default function Home() {
         >
           Why Choose Us?
         </h2>
-        {/* match hero divider styling */}
-        <div aria-hidden="true" className="self-start ml-0 h-px w-24 bg-silver" />
+        {/* replicate hero divider for visual consistency */}
+        <hr className="w-full border-t border-gray-600 my-4" />
         <p className="text-lg text-platinum">
           Keystone Notary Group, LLC provides professional, reliable, and
           convenient mobile notary services. We bring the notary public to you.


### PR DESCRIPTION
## Summary
- make `Why Choose Us` section divider full width
- match the Credentials divider style to the hero

## Testing
- `yarn test:run`
- `npx eslint src/pages/Home.jsx`

------
https://chatgpt.com/codex/tasks/task_b_686e01e4ca88832793668fa115b355c8