### PR TITLE
Fix responsive NNA badge layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Aligned badge center with the decorative underline for cleaner spacing.
 - Enlarged NNA badge by an additional 12% for improved visibility.- Restored NNA badge enlargement after rollback.
 - Ensured NNA badge uses responsive positioning to maintain placement across screen sizes.
+- Moved decorative underline to the `header` element so it spans both the heading and badge.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,3 +17,4 @@
 - Enlarged NNA badge slightly for better readability across devices.
 - Restored 10-15% NNA badge enlargement after rollback.
 - Ensured NNA badge uses responsive positioning to keep alignment consistent on all devices.
+- Decorative underline now lives on the `header` wrapper so it stretches under both the heading and badge.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -13,13 +13,14 @@ describe('Credentials component', () => {
     expect(badge).toBeInTheDocument();
   });
 
-  test('badge uses responsive positioning classes', () => {
+  test('badge uses responsive sizing classes', () => {
     render(<Credentials />);
     const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
     const className = badge.getAttribute('class');
-    expect(className).toEqual(
-      expect.stringContaining('absolute right-4 sm:right-10 top-1/2 sm:top-[calc(50%+1.25rem)] h-[8rem] w-auto -translate-y-1/2'),
-    );
+    expect(className).toEqual(expect.stringContaining('h-20'));
+    expect(className).toEqual(expect.stringContaining('w-auto'));
+    expect(className).toEqual(expect.stringContaining('sm:h-24'));
+    expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
   });
 
   const viewports = [320, 640, 1024, 1280];

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -19,35 +19,20 @@ export default function Credentials({ className = '' }) {
         className,
       )}
     >
-      <header className="relative flex justify-center">
-        {/*
-          Center heading to mirror other sections while preserving space for the
-          credential badge overlay.
-        */}
+      <header
+        className="heading-gradient inline-flex items-center justify-center gap-4"
+      >
         <h2
           id="credentials-heading"
-
-          /* Uniform width ensures the decorative underline matches other
-             headings. Additional padding keeps text clear of the badge. */
-          className="w-full pr-32 text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+          className="text-3xl font-serif font-semibold tracking-wide text-silver"
         >
           Credentials
         </h2>
-        {/* display NNA credential badge next to the heading */}
-        {/*
-          Position badge over the extended underline without shifting the
-          heading. Larger size improves readability across breakpoints.
-        */}
+        {/* Ensure badge stays beside heading across breakpoints */}
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-
-          /* Enlarged by an additional ~12% for improved visibility */
-          /*
-            Responsive offsets keep the badge in the same visual spot
-            across breakpoints without shifting surrounding elements.
-          */
-          className="absolute right-4 sm:right-10 top-1/2 sm:top-[calc(50%+1.25rem)] h-[8rem] w-auto -translate-y-1/2"
+          className="h-20 w-auto flex-shrink-0 sm:h-24"
           width="128"
           height="128"
         />


### PR DESCRIPTION
## Summary
- refactor `Credentials` header so the underline spans across heading and badge
- document fix in CHANGELOG and RELEASE_NOTES

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686e390d2a0483279ea74f133b399595