### PR TITLE
Align NNA badge with credentials underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Enlarged NNA badge by an additional 12% for improved visibility.- Restored NNA badge enlargement after rollback.
 - Ensured NNA badge uses responsive positioning to maintain placement across screen sizes.
 - Moved decorative underline to the `header` element so it spans both the heading and badge.
+- Shifted badge downward so its center aligns with the underline.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,3 +18,4 @@
 - Restored 10-15% NNA badge enlargement after rollback.
 - Ensured NNA badge uses responsive positioning to keep alignment consistent on all devices.
 - Decorative underline now lives on the `header` wrapper so it stretches under both the heading and badge.
+- Shifted badge downward to sit directly atop the underline across breakpoints.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -21,6 +21,7 @@ describe('Credentials component', () => {
     expect(className).toEqual(expect.stringContaining('w-auto'));
     expect(className).toEqual(expect.stringContaining('sm:h-24'));
     expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
+    expect(className).toEqual(expect.stringContaining('translate-y-1/2'));
   });
 
   const viewports = [320, 640, 1024, 1280];

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -31,7 +31,7 @@ export default function Credentials({ className = '' }) {
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="h-20 w-auto flex-shrink-0 sm:h-24"
+          className="h-20 w-auto flex-shrink-0 sm:h-24 translate-y-1/2"
           width="128"
           height="128"
         />
@@ -45,5 +45,4 @@ export default function Credentials({ className = '' }) {
           </li>
         ))}
       </ul>
-    </MotionSection>
-  );}
+    </MotionSection>  );}


### PR DESCRIPTION
## Summary
- nudge the NNA badge so its center overlaps the credentials underline
- verify badge styling in unit tests
- document alignment change in changelog and release notes

## Testing
- `yarn lint`
- `yarn test:run`


------
https://chatgpt.com/codex/tasks/task_b_686e49724df4832789f722f8782e08e4