### PR TITLE
Adjust NNA badge scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Ensured NNA badge uses responsive positioning to maintain placement across screen sizes.
 - Moved decorative underline to the `header` element so it spans both the heading and badge.
 - Shifted badge downward so its center aligns with the underline.
+- Enlarged NNA badge by 25% while keeping it centered on the underline.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,3 +19,4 @@
 - Ensured NNA badge uses responsive positioning to keep alignment consistent on all devices.
 - Decorative underline now lives on the `header` wrapper so it stretches under both the heading and badge.
 - Shifted badge downward to sit directly atop the underline across breakpoints.
+- Scaled NNA badge up by 25% while maintaining center alignment.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -21,7 +21,8 @@ describe('Credentials component', () => {
     expect(className).toEqual(expect.stringContaining('w-auto'));
     expect(className).toEqual(expect.stringContaining('sm:h-24'));
     expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
-    expect(className).toEqual(expect.stringContaining('translate-y-1/2'));
+    expect(className).toEqual(expect.stringContaining('translate-y-[62.5%]'));
+    expect(className).toEqual(expect.stringContaining('scale-125'));
   });
 
   const viewports = [320, 640, 1024, 1280];

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -31,7 +31,7 @@ export default function Credentials({ className = '' }) {
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="h-20 w-auto flex-shrink-0 sm:h-24 translate-y-1/2"
+          className="h-20 w-auto flex-shrink-0 sm:h-24 translate-y-[62.5%] scale-125"
           width="128"
           height="128"
         />
@@ -44,5 +44,4 @@ export default function Credentials({ className = '' }) {
             <span className="text-platinum">{cred}</span>
           </li>
         ))}
-      </ul>
-    </MotionSection>  );}
+      </ul>    </MotionSection>  );}


### PR DESCRIPTION
## Summary
- enlarge the NNA badge by 25%
- keep badge centered over the decorative underline
- update tests
- document change in changelog and release notes

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_686e4cbf55c48327a229f1f4cb0113b4