### PR TITLE
Align badge overlay per layout reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Shifted badge downward so its center aligns with the underline.
 - Enlarged NNA badge by 25% while keeping it centered on the underline.
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
+- Positioned final-size NNA badge absolutely so it no longer shifts surrounding layout.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,3 +21,4 @@
 - Shifted badge downward to sit directly atop the underline across breakpoints.
 - Scaled NNA badge up by 25% while maintaining center alignment.
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
+- Final-size badge now absolutely positioned to keep the heading centered.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -1,37 +1,42 @@
-import { render, screen } from '@testing-library/react';
-import { Credentials } from '../components';
+import { render, screen } from "@testing-library/react";
+import { Credentials } from "../components";
 
 function setViewport(width) {
   window.innerWidth = width;
-  window.dispatchEvent(new Event('resize'));
+  window.dispatchEvent(new Event("resize"));
 }
 
-describe('Credentials component', () => {
-  test('displays NNA badge image with alt text', () => {
+describe("Credentials component", () => {
+  test("displays NNA badge image with alt text", () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
+    const badge = screen.getByAltText(
+      /certified nna notary signing agent 2025 badge/i,
+    );
     expect(badge).toBeInTheDocument();
   });
 
-  test('badge uses expected attributes and classes', () => {
+  test("badge uses expected attributes and classes", () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
-    const className = badge.getAttribute('class');
-    expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
-    expect(className).toEqual(expect.stringContaining('translate-y-[62.5%]'));
-    expect(badge.getAttribute('width')).toBe('220');
-    expect(badge.getAttribute('height')).toBe('220');
+    const badge = screen.getByAltText(
+      /certified nna notary signing agent 2025 badge/i,
+    );
+    const className = badge.getAttribute("class");
+    expect(className).toEqual(expect.stringContaining("absolute"));
+    expect(className).toEqual(expect.stringContaining("translate-y-[62.5%]"));
+    expect(className).toEqual(expect.stringContaining("flex-shrink-0"));
+    expect(badge.getAttribute("width")).toBeNull();
+    expect(badge.getAttribute("height")).toBeNull();
   });
 
   const viewports = [320, 640, 1024, 1280];
 
-  test.each(viewports)('renders correctly at %ipx viewport', (width) => {
+  test.each(viewports)("renders correctly at %ipx viewport", (width) => {
     setViewport(width);
     render(<Credentials />);
     // Section should be accessible via its heading label
-    const region = screen.getByRole('region', { name: /credentials/i });
+    const region = screen.getByRole("region", { name: /credentials/i });
     expect(region).toBeInTheDocument();
-    const items = screen.getAllByRole('listitem');
+    const items = screen.getAllByRole("listitem");
     expect(items).toHaveLength(3);
   });
 });

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -1,13 +1,13 @@
-import CheckIcon from './CheckIcon';
-import MotionSection from './MotionSection';
-import clsx from 'clsx';
+import CheckIcon from "./CheckIcon";
+import MotionSection from "./MotionSection";
+import clsx from "clsx";
 
 // Provide optional className for additional layout control
-export default function Credentials({ className = '' }) {
+export default function Credentials({ className = "" }) {
   const credentials = [
-    'Licensed & Bonded',
-    'Certified Signing Agent',
-    'Member of National Notary Association',
+    "Licensed & Bonded",
+    "Certified Signing Agent",
+    "Member of National Notary Association",
   ];
 
   return (
@@ -15,11 +15,11 @@ export default function Credentials({ className = '' }) {
     <MotionSection
       aria-labelledby="credentials-heading"
       className={clsx(
-        'container mt-12 border-t border-deepgray py-8 text-center flex flex-col gap-6',
+        "container mt-12 border-t border-deepgray py-8 text-center flex flex-col gap-6",
         className,
       )}
     >
-      <header className="heading-gradient flex flex-nowrap items-center justify-center gap-4">
+      <header className="heading-gradient relative flex justify-center">
         {/* Keep underline consistent with other headings */}
         <h2
           id="credentials-heading"
@@ -31,16 +31,19 @@ export default function Credentials({ className = '' }) {
         <img
           src="/nna-badge.png"
           alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="flex-shrink-0 translate-y-[62.5%]"
-          width="220"
-          height="220"
+          className="absolute right-4 top-1/2 translate-y-[62.5%] flex-shrink-0 pointer-events-none select-none"
         />
       </header>
-
       <ul className="mx-auto w-max flex flex-col gap-4 text-left">
         {credentials.map((cred) => (
           <li key={cred} className="flex items-start justify-start">
-            <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
-            <span className="text-platinum">{cred}</span>
-          </li>        ))}
-      </ul>    </MotionSection>  );}
+            <CheckIcon
+              className="mr-2 h-5 w-5 text-silver"
+              aria-hidden="true"
+            />
+            <span className="text-platinum">{cred}</span>          </li>
+        ))}
+      </ul>
+    </MotionSection>
+  );
+}


### PR DESCRIPTION
## Summary
- prevent NNA badge from shifting layout
- position badge absolutely beside heading
- adjust tests for new positioning
- document final badge alignment in changelog and release notes

## Testing
- `yarn lint`
- `yarn test:run`


------
https://chatgpt.com/codex/tasks/task_b_686ededa86c08327961824e5318b55d5