### PR TITLE
Fix credentials heading layout

### DIFF
--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -21,9 +21,11 @@ describe("Credentials component", () => {
       /certified nna notary signing agent 2025 badge/i,
     );
     const className = badge.getAttribute("class");
-    expect(className).toEqual(expect.stringContaining("absolute"));
-    expect(className).toEqual(expect.stringContaining("translate-y-[62.5%]"));
-    expect(className).toEqual(expect.stringContaining("flex-shrink-0"));
+    expect(className).toEqual(expect.stringContaining("relative"));
+    expect(className).toEqual(expect.stringContaining("w-32"));
+    expect(className).toEqual(expect.stringContaining("h-32"));
+    expect(className).toEqual(expect.stringContaining("-my-8"));
+    expect(className).toEqual(expect.stringContaining("drop-shadow-xl"));
     expect(badge.getAttribute("width")).toBeNull();
     expect(badge.getAttribute("height")).toBeNull();
   });

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -19,20 +19,28 @@ export default function Credentials({ className = "" }) {
         className,
       )}
     >
-      <header className="flex justify-center">
-        {/* Wrapper preserves underline width while isolating badge from layout */}
-        <div className="heading-gradient relative inline-block">
+      <header className="flex justify-start">
+        <div
+          className="relative flex flex-row items-center w-full"
+          style={{ minHeight: '7rem' }}
+        >
+          {/* Decorative line fully behind heading and badge */}
+          <div className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-0.5 bg-gray-400 z-0" />
+          {/* Heading */}
           <h2
             id="credentials-heading"
-            className="text-3xl font-serif font-semibold tracking-wide text-silver"
+            className="relative z-10 text-4xl font-serif font-semibold tracking-wide text-silver bg-black pr-4"
+            style={{ lineHeight: 1 }}
           >
             Credentials
           </h2>
-          {/* Badge overlays the heading exactly as in reference image */}
+          {/* Badge */}
           <img
             src="/nna-badge.png"
             alt="Certified NNA Notary Signing Agent 2025 badge"
-            className="absolute right-4 top-1/2 translate-y-[62.5%] flex-shrink-0 pointer-events-none select-none"
+            className="relative z-10 w-32 h-32 -my-8 ml-2 drop-shadow-xl pointer-events-none select-none bg-black"
+            style={{ objectFit: 'contain' }}
+            draggable={false}
           />
         </div>
       </header>
@@ -49,5 +57,4 @@ export default function Credentials({ className = "" }) {
         ))}
       </ul>
     </MotionSection>
-  );
-}
+  );}


### PR DESCRIPTION
## Summary
- refine credentials header to show horizontal line behind heading and badge
- update tests for new credential header classes

## Testing
- `npx eslint "src/**/*.{js,jsx}"`
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686efaca2d488327812d7c7d0a3e3628