### PR TITLE
Fix Credentials header styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Enlarged NNA badge by 25% while keeping it centered on the underline.
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
 - Positioned final-size NNA badge absolutely so it no longer shifts surrounding layout.
+- Removed background and padding on Credentials heading and badge, keeping line visible behind both elements.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,3 +22,4 @@
 - Scaled NNA badge up by 25% while maintaining center alignment.
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
 - Final-size badge now absolutely positioned to keep the heading centered.
+- Removed background and padding from the Credentials heading and badge so the underline shows continuously behind them.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -22,8 +22,8 @@ describe("Credentials component", () => {
     );
     const className = badge.getAttribute("class");
     expect(className).toEqual(expect.stringContaining("relative"));
-    expect(className).toEqual(expect.stringContaining("w-32"));
-    expect(className).toEqual(expect.stringContaining("h-32"));
+    expect(className).toEqual(expect.stringContaining("w-28"));
+    expect(className).toEqual(expect.stringContaining("h-28"));
     expect(className).toEqual(expect.stringContaining("-my-8"));
     expect(className).toEqual(expect.stringContaining("drop-shadow-xl"));
     expect(badge.getAttribute("width")).toBeNull();

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -19,31 +19,29 @@ export default function Credentials({ className = "" }) {
         className,
       )}
     >
-      <header className="flex justify-start">
-        <div
-          className="relative flex flex-row items-center w-full"
-          style={{ minHeight: '7rem' }}
-        >
-          {/* Decorative line fully behind heading and badge */}
-          <div className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-0.5 bg-gray-400 z-0" />
-          {/* Heading */}
-          <h2
-            id="credentials-heading"
-            className="relative z-10 text-4xl font-serif font-semibold tracking-wide text-silver bg-black pr-4"
-            style={{ lineHeight: 1 }}
+        <header className="flex justify-start w-full">
+          <div
+            className="relative flex flex-row items-center w-full"
+            style={{ minHeight: '7rem' }}
           >
-            Credentials
-          </h2>
-          {/* Badge */}
-          <img
-            src="/nna-badge.png"
-            alt="Certified NNA Notary Signing Agent 2025 badge"
-            className="relative z-10 w-32 h-32 -my-8 ml-2 drop-shadow-xl pointer-events-none select-none bg-black"
-            style={{ objectFit: 'contain' }}
-            draggable={false}
-          />
-        </div>
-      </header>
+            {/* Decorative line runs fully behind both heading and badge */}
+            <div className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-0.5 bg-gray-400 z-0" />
+            <h2
+              id="credentials-heading"
+              className="relative z-10 text-4xl font-serif font-semibold tracking-wide text-silver"
+              style={{ lineHeight: 1 }}
+            >
+              Credentials
+            </h2>
+            <img
+              src="/nna-badge.png"
+              alt="Certified NNA Notary Signing Agent 2025 badge"
+              className="relative z-10 w-28 h-28 -my-8 ml-2 drop-shadow-xl pointer-events-none select-none"
+              style={{ objectFit: 'contain' }}
+              draggable={false}
+            />
+          </div>
+        </header>
 
       <ul className="mx-auto w-max flex flex-col gap-4 text-left">
         {credentials.map((cred) => (
@@ -56,5 +54,4 @@ export default function Credentials({ className = "" }) {
           </li>
         ))}
       </ul>
-    </MotionSection>
-  );}
+    </MotionSection>  );}


### PR DESCRIPTION
## Summary
- keep Credentials heading and badge in a single flex row
- remove background and padding from heading and badge
- adjust badge size to w-28/h-28
- update tests
- document change in CHANGELOG and RELEASE_NOTES

## Testing
- `yarn lint`
- `yarn test:run`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_686efd7d117c83279c36e8467520ff52