### PR TITLE
Add official NNA badge stamp

### DIFF
--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -10,7 +10,7 @@ describe("Credentials component", () => {
   test("displays NNA badge image with alt text", () => {
     render(<Credentials />);
     const badge = screen.getByAltText(
-      /certified nna notary signing agent 2025 badge/i,
+      /nna certified notary signing agent 2025 badge/i,
     );
     expect(badge).toBeInTheDocument();
   });
@@ -18,13 +18,14 @@ describe("Credentials component", () => {
   test("badge uses expected attributes and classes", () => {
     render(<Credentials />);
     const badge = screen.getByAltText(
-      /certified nna notary signing agent 2025 badge/i,
+      /nna certified notary signing agent 2025 badge/i,
     );
     const className = badge.getAttribute("class");
-    expect(className).toEqual(expect.stringContaining("relative"));
-    expect(className).toEqual(expect.stringContaining("w-28"));
-    expect(className).toEqual(expect.stringContaining("h-28"));
-    expect(className).toEqual(expect.stringContaining("-my-8"));
+    expect(className).toEqual(expect.stringContaining("absolute"));
+    expect(className).toEqual(expect.stringContaining("-bottom-8"));
+    expect(className).toEqual(expect.stringContaining("-right-8"));
+    expect(className).toEqual(expect.stringContaining("w-32"));
+    expect(className).toEqual(expect.stringContaining("h-32"));
     expect(className).toEqual(expect.stringContaining("drop-shadow-xl"));
     expect(badge.getAttribute("width")).toBeNull();
     expect(badge.getAttribute("height")).toBeNull();

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -11,11 +11,10 @@ export default function Credentials({ className = "" }) {
   ];
 
   return (
-    // Top margin and border create clear division from prior section
     <MotionSection
       aria-labelledby="credentials-heading"
       className={clsx(
-        "container mt-12 border-t border-deepgray py-8 text-center flex flex-col gap-6",
+        "relative bg-black max-w-xl mx-auto p-8 rounded-lg shadow-lg",
         className,
       )}
     >
@@ -33,13 +32,6 @@ export default function Credentials({ className = "" }) {
             >
               Credentials
             </h2>
-            <img
-              src="/nna-badge.png"
-              alt="Certified NNA Notary Signing Agent 2025 badge"
-              className="relative z-10 w-28 h-28 -my-8 ml-2 drop-shadow-xl pointer-events-none select-none"
-              style={{ objectFit: 'contain' }}
-              draggable={false}
-            />
           </div>
         </header>
 
@@ -54,4 +46,13 @@ export default function Credentials({ className = "" }) {
           </li>
         ))}
       </ul>
-    </MotionSection>  );}
+      <img
+        src="/nna-badge.png"
+        className="absolute -bottom-8 -right-8 w-32 h-32 drop-shadow-xl pointer-events-none select-none"
+        style={{ zIndex: 10 }}
+        alt="NNA Certified Notary Signing Agent 2025 badge"
+        draggable={false}
+      />
+    </MotionSection>
+  );
+}


### PR DESCRIPTION
## Summary
- show the official NNA Signing Agent badge overlapping the Credentials box
- update tests for new badge position and alt text

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview` *(fails: process terminated after start)*

------
https://chatgpt.com/codex/tasks/task_b_686f40a44c9c8327a7ba40bf6fb8cec4