### PR TITLE
Fix Credentials badge layout

### DIFF
--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -21,11 +21,14 @@ describe("Credentials component", () => {
       /nna certified notary signing agent 2025 badge/i,
     );
     const className = badge.getAttribute("class");
-    expect(className).toEqual(expect.stringContaining("block"));
-    expect(className).toEqual(expect.stringContaining("ml-auto"));
-    expect(className).toEqual(expect.stringContaining("mt-4"));
-    expect(className).toEqual(expect.stringContaining("w-28"));
-    expect(className).toEqual(expect.stringContaining("h-28"));
+    expect(className).toEqual(expect.stringContaining("mx-auto"));
+    expect(className).toEqual(expect.stringContaining("mt-6"));
+    expect(className).toEqual(expect.stringContaining("sm:mt-0"));
+    expect(className).toEqual(expect.stringContaining("sm:ml-8"));
+    expect(className).toEqual(expect.stringContaining("w-24"));
+    expect(className).toEqual(expect.stringContaining("h-24"));
+    expect(className).toEqual(expect.stringContaining("sm:w-28"));
+    expect(className).toEqual(expect.stringContaining("sm:h-28"));
     expect(className).toEqual(expect.stringContaining("drop-shadow-xl"));
     expect(className).toEqual(expect.stringContaining("pointer-events-none"));
     expect(className).toEqual(expect.stringContaining("select-none"));

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -14,11 +14,11 @@ export default function Credentials({ className = "" }) {
     <MotionSection
       aria-labelledby="credentials-heading"
       className={clsx(
-        "relative bg-black max-w-xl mx-auto p-8 rounded-lg shadow-lg",
+        "relative bg-black max-w-xl mx-auto p-8 rounded-lg shadow-lg mt-4 sm:mt-8",
         className,
       )}
     >
-      <header className="sticky top-0 z-20 bg-black pb-2">
+      <header className="pb-2">
         <h2
           id="credentials-heading"
           className="text-4xl font-serif font-semibold tracking-wide text-silver"
@@ -29,7 +29,7 @@ export default function Credentials({ className = "" }) {
         <div className="mt-2 h-px w-full bg-gray-400" />
       </header>
 
-      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between">
         <ul className="flex flex-col gap-4 text-left">
           {credentials.map((cred) => (
             <li key={cred} className="flex items-start justify-start">
@@ -40,7 +40,7 @@ export default function Credentials({ className = "" }) {
         </ul>
         <img
           src="/nna-badge.png"
-          className="block ml-auto mt-4 w-28 h-28 drop-shadow-xl pointer-events-none select-none"
+          className="mx-auto mt-6 sm:mt-0 sm:ml-8 w-24 h-24 sm:w-28 sm:h-28 drop-shadow-xl pointer-events-none select-none"
           alt="NNA Certified Notary Signing Agent 2025 badge"
           draggable={false}
         />


### PR DESCRIPTION
## Summary
- adjust Credentials layout for cleaner spacing and responsive badge placement
- update unit test expectations for the badge classes

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_b_686f4911d0008327b2010629d6c40b27