### PR TITLE
Fix credentials layout regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
 - Positioned final-size NNA badge absolutely so it no longer shifts surrounding layout.
 - Removed background and padding on Credentials heading and badge, keeping line visible behind both elements.
+- Reverted Credentials layout to stable version with 220x220 NNA badge.
 
 ## [1.0.0] - YYYY-MM-DD
 ### Added

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,3 +23,4 @@
 - Replaced NNA badge image with a 220x220 asset to remove scaling.
 - Final-size badge now absolutely positioned to keep the heading centered.
 - Removed background and padding from the Credentials heading and badge so the underline shows continuously behind them.
+- Reverted Credentials layout to stable version with 220x220 NNA badge.

--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -1,48 +1,37 @@
-import { render, screen } from "@testing-library/react";
-import { Credentials } from "../components";
+import { render, screen } from '@testing-library/react';
+import { Credentials } from '../components';
 
 function setViewport(width) {
   window.innerWidth = width;
-  window.dispatchEvent(new Event("resize"));
+  window.dispatchEvent(new Event('resize'));
 }
 
-describe("Credentials component", () => {
-  test("displays NNA badge image with alt text", () => {
+describe('Credentials component', () => {
+  test('displays NNA badge image with alt text', () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(
-      /nna certified notary signing agent 2025 badge/i,
-    );
+    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
     expect(badge).toBeInTheDocument();
   });
 
-  test("badge uses expected attributes and classes", () => {
+  test('badge uses expected attributes and classes', () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(
-      /nna certified notary signing agent 2025 badge/i,
-    );
-    const className = badge.getAttribute("class");
-    expect(className).toEqual(expect.stringContaining("mx-auto"));
-    expect(className).toEqual(expect.stringContaining("mt-6"));
-    expect(className).toEqual(expect.stringContaining("sm:mt-0"));
-    expect(className).toEqual(expect.stringContaining("sm:ml-8"));
-    expect(className).toEqual(expect.stringContaining("w-24"));
-    expect(className).toEqual(expect.stringContaining("h-24"));
-    expect(className).toEqual(expect.stringContaining("sm:w-28"));
-    expect(className).toEqual(expect.stringContaining("sm:h-28"));
-    expect(className).toEqual(expect.stringContaining("drop-shadow-xl"));
-    expect(className).toEqual(expect.stringContaining("pointer-events-none"));
-    expect(className).toEqual(expect.stringContaining("select-none"));
+    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
+    const className = badge.getAttribute('class');
+    expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
+    expect(className).toEqual(expect.stringContaining('translate-y-[62.5%]'));
+    expect(badge.getAttribute('width')).toBe('220');
+    expect(badge.getAttribute('height')).toBe('220');
   });
 
   const viewports = [320, 640, 1024, 1280];
 
-  test.each(viewports)("renders correctly at %ipx viewport", (width) => {
+  test.each(viewports)('renders correctly at %ipx viewport', (width) => {
     setViewport(width);
     render(<Credentials />);
     // Section should be accessible via its heading label
-    const region = screen.getByRole("region", { name: /credentials/i });
+    const region = screen.getByRole('region', { name: /credentials/i });
     expect(region).toBeInTheDocument();
-    const items = screen.getAllByRole("listitem");
+    const items = screen.getAllByRole('listitem');
     expect(items).toHaveLength(3);
   });
 });

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -1,50 +1,50 @@
-import CheckIcon from "./CheckIcon";
-import MotionSection from "./MotionSection";
-import clsx from "clsx";
+import CheckIcon from './CheckIcon';
+import MotionSection from './MotionSection';
+import clsx from 'clsx';
 
 // Provide optional className for additional layout control
-export default function Credentials({ className = "" }) {
+export default function Credentials({ className = '' }) {
   const credentials = [
-    "Licensed & Bonded",
-    "Certified Signing Agent",
-    "Member of National Notary Association",
+    'Licensed & Bonded',
+    'Certified Signing Agent',
+    'Member of National Notary Association',
   ];
 
   return (
+    // Top margin and border create clear division from prior section
     <MotionSection
       aria-labelledby="credentials-heading"
       className={clsx(
-        "relative bg-black max-w-xl mx-auto p-8 rounded-lg shadow-lg mt-4 sm:mt-8",
+        'container mt-12 border-t border-deepgray py-8 text-center flex flex-col gap-6',
         className,
       )}
     >
-      <header className="pb-2">
+      <header className="heading-gradient flex flex-nowrap items-center justify-center gap-4">
+        {/* Keep underline consistent with other headings */}
         <h2
           id="credentials-heading"
-          className="text-4xl font-serif font-semibold tracking-wide text-silver"
-          style={{ lineHeight: 1 }}
+          className="text-3xl font-serif font-semibold tracking-wide text-silver"
         >
           Credentials
         </h2>
-        <div className="mt-2 h-px w-full bg-gray-400" />
-      </header>
-
-      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between">
-        <ul className="flex flex-col gap-4 text-left">
-          {credentials.map((cred) => (
-            <li key={cred} className="flex items-start justify-start">
-              <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
-              <span className="text-platinum">{cred}</span>
-            </li>
-          ))}
-        </ul>
+        {/* Ensure badge stays beside heading across breakpoints */}
         <img
           src="/nna-badge.png"
-          className="mx-auto mt-6 sm:mt-0 sm:ml-8 w-24 h-24 sm:w-28 sm:h-28 drop-shadow-xl pointer-events-none select-none"
-          alt="NNA Certified Notary Signing Agent 2025 badge"
-          draggable={false}
+          alt="Certified NNA Notary Signing Agent 2025 badge"
+          className="flex-shrink-0 translate-y-[62.5%]"
+          width="220"
+          height="220"
         />
-      </div>
+      </header>
+
+      <ul className="mx-auto w-max flex flex-col gap-4 text-left">
+        {credentials.map((cred) => (
+          <li key={cred} className="flex items-start justify-start">
+            <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
+            <span className="text-platinum">{cred}</span>
+          </li>
+        ))}
+      </ul>
     </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- revert Credentials layout to stable version with 220x220 badge
- update tests for reverted layout
- document regression fix in changelog and release notes

## Testing
- `yarn lint`
- `npx eslint src/components/Credentials.jsx -f unix`
- `yarn test:run`


------
https://chatgpt.com/codex/tasks/task_b_686f578408b0832786e4ebceb3d9d7fc