### PR TITLE
Fix credentials badge layout

### DIFF
--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -9,18 +9,28 @@ function setViewport(width) {
 describe('Credentials component', () => {
   test('displays NNA badge image with alt text', () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
+    const badge = screen.getByAltText(/nna certified notary signing agent 2025 badge/i);
     expect(badge).toBeInTheDocument();
   });
 
   test('badge uses expected attributes and classes', () => {
     render(<Credentials />);
-    const badge = screen.getByAltText(/certified nna notary signing agent 2025 badge/i);
+    const badge = screen.getByAltText(/nna certified notary signing agent 2025 badge/i);
     const className = badge.getAttribute('class');
-    expect(className).toEqual(expect.stringContaining('flex-shrink-0'));
-    expect(className).toEqual(expect.stringContaining('translate-y-[62.5%]'));
-    expect(badge.getAttribute('width')).toBe('220');
-    expect(badge.getAttribute('height')).toBe('220');
+    expect(className).toEqual(expect.stringContaining('w-[220px]'));
+    expect(className).toEqual(expect.stringContaining('h-[220px]'));
+    expect(className).toEqual(expect.stringContaining('mx-auto'));
+    expect(className).toEqual(expect.stringContaining('sm:ml-8'));
+    expect(badge.getAttribute('draggable')).toBe('false');
+  });
+
+  test('layout container uses responsive flex classes', () => {
+    render(<Credentials />);
+    const badge = screen.getByAltText(/nna certified notary signing agent 2025 badge/i);
+    const container = badge.parentElement;
+    const className = container?.getAttribute('class') || '';
+    expect(className).toEqual(expect.stringContaining('flex-col'));
+    expect(className).toEqual(expect.stringContaining('sm:flex-row'));
   });
 
   const viewports = [320, 640, 1024, 1280];

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -19,32 +19,30 @@ export default function Credentials({ className = '' }) {
         className,
       )}
     >
-      <header className="heading-gradient flex flex-nowrap items-center justify-center gap-4">
-        {/* Keep underline consistent with other headings */}
-        <h2
-          id="credentials-heading"
-          className="text-3xl font-serif font-semibold tracking-wide text-silver"
-        >
-          Credentials
-        </h2>
-        {/* Ensure badge stays beside heading across breakpoints */}
+      <h2
+        id="credentials-heading"
+        className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      >
+        Credentials
+      </h2>
+
+      {/* Badge sits beside the credentials list on desktop and below on mobile */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between">
+        <ul className="flex flex-col gap-4 text-left">
+          {credentials.map((cred) => (
+            <li key={cred} className="flex items-start">
+              <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
+              <span className="text-platinum">{cred}</span>
+            </li>
+          ))}
+        </ul>
         <img
           src="/nna-badge.png"
-          alt="Certified NNA Notary Signing Agent 2025 badge"
-          className="flex-shrink-0 translate-y-[62.5%]"
-          width="220"
-          height="220"
+          alt="NNA Certified Notary Signing Agent 2025 badge"
+          className="w-[220px] h-[220px] mx-auto mt-6 sm:mt-0 sm:ml-8 drop-shadow-xl pointer-events-none select-none"
+          draggable={false}
         />
-      </header>
-
-      <ul className="mx-auto w-max flex flex-col gap-4 text-left">
-        {credentials.map((cred) => (
-          <li key={cred} className="flex items-start justify-start">
-            <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
-            <span className="text-platinum">{cred}</span>
-          </li>
-        ))}
-      </ul>
+      </div>
     </MotionSection>
   );
 }


### PR DESCRIPTION
## Summary
- place badge next to credentials list in a responsive flex container
- keep badge fixed at 220x220 with no offsets or translations
- update unit tests for new markup and classes

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_686f5e9213748327a6498d4e01410073