### PR TITLE
Add hero logo for Keystone home page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Hero section now displays company parchment logo with responsive sizing.
+
 - Reverted to "Audit and secure code base for HTTPS" patch state.
 - Extended decorative underline for section headings and positioned
   NNA badge over the Credentials line.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,12 @@
 - Updated key dependencies to current minor versions.
 - Cleaned up MotionSection component formatting.
 
+## Version 1.0.4 – YYYY-MM-DD
+
+### Added
+
+- Hero section displays parchment logo at the top with responsive sizes.
+
 ## Version 1.0.1 – YYYY-MM-DD
 
 ### Changes

--- a/src/__tests__/Hero.test.jsx
+++ b/src/__tests__/Hero.test.jsx
@@ -18,5 +18,8 @@ describe('Hero component', () => {
     expect(
       screen.getByRole('link', { name: /call or text 267-309-9000/i }),
     ).toHaveAttribute('href', 'tel:2673099000');
+    expect(
+      screen.getByAltText(/keystone notary group, llc parchment logo/i),
+    ).toBeInTheDocument();
   });
 });

--- a/src/__tests__/Home.test.jsx
+++ b/src/__tests__/Home.test.jsx
@@ -13,6 +13,8 @@ test('renders home page heading and cta', () => {
   expect(cta).toHaveAttribute('href', '/contact#contact');
   const phoneLink = screen.getByRole('link', { name: /call or text/i });
   expect(phoneLink).toHaveAttribute('href', 'tel:2673099000');
-  // Hero should not display a placeholder logo image
-  expect(screen.queryByAltText(/keystone notary group logo/i)).not.toBeInTheDocument();
+  // Hero displays the parchment logo for brand recognition
+  expect(
+    screen.getByAltText(/keystone notary group, llc parchment logo/i),
+  ).toBeInTheDocument();
 });

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -8,7 +8,7 @@ const MotionLink = motion.create(Link);
 
 export default function Hero() {
   return (
-    <section className="relative flex min-h-screen w-full items-center justify-center px-4 text-center sm:px-8">
+    <section className="relative flex min-h-screen w-full items-center justify-center bg-black px-4 text-center sm:px-8">
       {/* Semi-transparent overlay for better text readability over the background */}
       <div className="absolute inset-0 bg-black/80" />
       <motion.div
@@ -17,6 +17,15 @@ export default function Hero() {
         transition={{ duration: 0.8 }}
         className="relative z-10 flex w-full flex-col items-center gap-8 px-4 sm:px-8 lg:gap-10"
       >
+        {/* Company logo displayed prominently at the top of the hero */}
+        <img
+          src="/hero-logo.PNG"
+          alt="Keystone Notary Group, LLC parchment logo"
+          width="1024"
+          height="1024"
+          className="mx-auto w-[300px] sm:w-[350px] md:w-[400px] lg:w-[450px] max-w-full h-auto mt-10 mb-6 drop-shadow-lg"
+          draggable={false}
+        />
         <h1 className="hero-heading w-full text-4xl font-serif font-semibold tracking-wide heading-gradient lg:text-6xl">
           Keystone Notary Group, LLC
         </h1>


### PR DESCRIPTION
## Summary
- display the parchment logo above the hero heading
- verify logo rendering in Home and Hero tests
- document new hero logo in CHANGELOG and RELEASE_NOTES

## Testing
- `yarn test:run`
- `yarn lint`
- `yarn build`
- `yarn preview` *(fails: hung server, killed)*

------
https://chatgpt.com/codex/tasks/task_b_686f910ac06c8327abde6f04ae0391eb