### PR TITLE
Polish hero and chat components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to this project will be documented in this file.
 - Removed background and padding on Credentials heading and badge, keeping line visible behind both elements.
 - Reverted Credentials layout to stable version with 220x220 NNA badge.
 
+### Changed
+- Polished hero layout and tagline color for consistent branding.
+- Enhanced navigation link transitions and focus visibility.
+- Refined chat widget sizing and input focus styling.
+- Removed obsolete development TODO comment.
+
 ## [1.0.2] - YYYY-MM-DD
 
 ### Changed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Version 1.0.8 – YYYY-MM-DD
+
+### Changed
+
+- Fine-tuned hero alignment and tagline color.
+- Added navigation link transitions with visible focus rings.
+- Adjusted chat widget dimensions and input styling for accessibility.
+- Removed obsolete development TODO comment.
+
 ## Version 1.0.0 – YYYY-MM-DD
 
 ### Features

--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -21,7 +21,6 @@ const findAnswer = (question) => {
   return FAQ.find(({ q }) => normalized.includes(q.toLowerCase()));
 };
 
-// TODO(phase-2): Replace findAnswer logic with OpenAI API call for dynamic responses.
 
 export default function ChatWidget() {
   const [open, setOpen] = useState(false);
@@ -124,14 +123,14 @@ export default function ChatWidget() {
               type="button"
               aria-label="Close chat"
               onClick={() => setOpen(false)}
-              className="fixed inset-0 z-40 bg-black/50"
+              className="fixed inset-0 z-40 bg-black/50 focus:outline-none"
             />
             <motion.div
               key="chat"
               role="dialog"
               aria-label="Ask a Notary"
               ref={chatRef}
-              className="fixed bottom-0 left-0 right-0 z-50 m-4 flex max-h-[80vh] w-[92vw] max-w-[92vw] flex-col overflow-hidden rounded-2xl border border-[#E5E4E2]/80 bg-black/80 text-platinum shadow-2xl backdrop-blur-md sm:bottom-4 sm:left-auto sm:right-4 sm:w-[370px]"
+              className="fixed bottom-0 left-0 right-0 z-50 m-4 flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[#E5E4E2]/80 bg-black/80 text-platinum shadow-2xl backdrop-blur-md sm:bottom-4 sm:left-auto sm:right-4 sm:w-[370px]"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: 20 }}
@@ -201,7 +200,7 @@ export default function ChatWidget() {
                   name="question"
                   ref={inputRef}
                   type="text"
-                  className="flex-1 rounded-full border border-silver/70 bg-transparent px-3 py-2 text-white placeholder-platinum focus:outline-none focus:ring-2 focus:ring-silver"
+                  className="flex-1 rounded-full border border-silver/70 bg-transparent px-3 py-3 text-white placeholder-platinum transition-shadow focus:outline-none focus:ring-2 focus:ring-silver focus:ring-offset-2 focus:ring-offset-black"
                   placeholder="Ask a question..."
                   autoComplete="off"
                 />

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -15,7 +15,7 @@ export default function Hero() {
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.8 }}
-        className="relative z-10 flex w-full flex-col items-center gap-8 px-4 sm:px-8 lg:gap-10"
+        className="relative z-10 mx-auto flex w-full max-w-4xl flex-col items-center gap-8 px-4 sm:px-8 lg:gap-10"
       >
         {/*
           Group brand elements for easier layout tuning and animation hooks.
@@ -37,7 +37,7 @@ export default function Hero() {
             Keystone Notary Group, LLC
           </h1>
         </header>
-        <p className="text-lg font-light lg:text-2xl">Reliable Mobile Notary Services</p>
+        <p className="text-lg font-light text-silver lg:text-2xl">Reliable Mobile Notary Services</p>
         <a
           href="tel:2673099000"
           aria-label="Call or text 267-309-9000"

--- a/src/components/variants.js
+++ b/src/components/variants.js
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const inputStyles = tv({
-  base: 'w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none',
+  base: 'w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none focus:ring-2 focus:ring-silver transition-colors duration-200',
   variants: {
     disabled: {
       true: 'opacity-50 cursor-not-allowed',
@@ -10,7 +10,7 @@ export const inputStyles = tv({
 });
 
 export const navLinkStyles = tv({
-  base: 'block rounded border border-transparent bg-deepgray px-3 py-2 text-lg font-medium transition-colors hover:bg-charcoal hover:border-silver hover:text-silver hover:shadow',
+  base: 'block rounded border border-transparent bg-deepgray px-3 py-2 text-lg font-medium transition-colors duration-200 hover:bg-charcoal hover:border-silver hover:text-silver hover:shadow focus:outline-none focus:ring focus:ring-silver',
   variants: {
     active: {
       true: 'text-silver shadow-inner',

--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@
   }
 
   .cta-button {
-    @apply inline-block rounded border border-platinum bg-deepgray px-8 py-3 text-lg font-medium text-white transition-colors;
+    @apply inline-block rounded border border-platinum bg-deepgray px-8 py-3 text-lg font-medium text-white transition-colors transition-transform duration-200;
   }
 
 


### PR DESCRIPTION
## Summary
- refine hero layout and tagline color
- tighten nav and form variants
- improve chat widget width and input focus
- document polish in changelog and release notes

## Testing
- `npm run lint`
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_b_686fda852d248327942c5640716fa80b