### PR TITLE
Restore polished contact page and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Home from './pages/Home';
 import About from './pages/About';
 import Services from './pages/Services';
 import FAQ from './pages/FAQ';
+import Contact from './pages/Contact';
 import Prices from './pages/Prices';
 import NotFound from './pages/NotFound';
 
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="services" element={<Services />} />
         <Route path="prices" element={<Prices />} />
         <Route path="faq" element={<FAQ />} />
+        <Route path="contact" element={<Contact />} />
         <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>

--- a/src/__tests__/Contact.test.jsx
+++ b/src/__tests__/Contact.test.jsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+
+test('renders contact form', () => {
+  render(
+    <MemoryRouter initialEntries={['/contact']} future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+      <App />
+    </MemoryRouter>
+  );
+  expect(screen.getByRole('heading', { name: /contact us/i })).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /send message/i })).toBeInTheDocument();
+});

--- a/src/components/ContactFields.jsx
+++ b/src/components/ContactFields.jsx
@@ -1,0 +1,173 @@
+import { inputStyles } from './variants';
+
+export default function ContactFields({
+  formData,
+  errors,
+  onChange,
+  requestAppointment,
+  setRequestAppointment,
+  setErrors,
+}) {
+  return (
+    <fieldset className="space-y-4">
+      <label className="block" htmlFor="name">
+        <span className="mb-1 block text-platinum">Full Name</span>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          required
+          value={formData.name}
+          onChange={onChange}
+          aria-invalid={!!errors.name}
+          className={inputStyles()}
+        />
+        {errors.name && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.name}
+          </p>
+        )}
+      </label>
+      <label className="block" htmlFor="email">
+        <span className="mb-1 block text-platinum">Email Address</span>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          required
+          value={formData.email}
+          onChange={onChange}
+          aria-invalid={!!errors.email}
+          className={inputStyles()}
+        />
+        {errors.email && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.email}
+          </p>
+        )}
+      </label>
+      <label className="block" htmlFor="phone">
+        <span className="mb-1 block text-platinum">Phone Number</span>
+        <input
+          id="phone"
+          name="phone"
+          type="tel"
+          value={formData.phone}
+          onChange={onChange}
+          className={inputStyles()}
+        />
+      </label>
+      <label className="block" htmlFor="documentCategory">
+        <span className="mb-1 block text-platinum">Document Category</span>
+        <select
+          id="documentCategory"
+          name="documentCategory"
+          required
+          value={formData.documentCategory}
+          onChange={onChange}
+          aria-invalid={!!errors.documentCategory}
+          className={inputStyles()}
+        >
+          <option value="">Select a category</option>
+          <option value="real_estate">Real Estate / Loan</option>
+          <option value="personal">Personal Document</option>
+          <option value="business">Business Document</option>
+          <option value="other">Other</option>
+        </select>
+        {errors.documentCategory && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.documentCategory}
+          </p>
+        )}
+      </label>
+      <label className="flex items-center gap-2" htmlFor="requestAppointment">
+        <input
+          id="requestAppointment"
+          name="requestAppointment"
+          type="checkbox"
+          checked={requestAppointment}
+          onChange={(e) => {
+            const checked = e.target.checked;
+            setRequestAppointment(checked);
+            if (!checked) {
+              setErrors((prev) => {
+                const { date, time, appointmentType, ...rest } = prev;
+                void date;
+                void time;
+                void appointmentType;
+                return rest;
+              });
+            }
+          }}
+          className="h-5 w-5 accent-silver"
+        />
+        <span className="text-platinum">I am requesting an appointment.</span>
+      </label>
+      <label className="block" htmlFor="appointmentType">
+        <span className="mb-1 block text-platinum">Appointment Type</span>
+        <select
+          id="appointmentType"
+          name="appointmentType"
+          disabled={!requestAppointment}
+          required={requestAppointment}
+          value={formData.appointmentType}
+          onChange={onChange}
+          aria-invalid={!!errors.appointmentType}
+          className={inputStyles()}
+        >
+          <option value="">Select type</option>
+          <option value="in_person">In-Person</option>
+          <option value="remote">Remote/Online</option>
+        </select>
+        {errors.appointmentType && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.appointmentType}
+          </p>
+        )}
+      </label>
+      <label className="block" htmlFor="date">
+        <span className="mb-1 block text-platinum">Preferred Date</span>
+        <input
+          id="date"
+          name="date"
+          type="date"
+          disabled={!requestAppointment}
+          required={requestAppointment}
+          value={formData.date}
+          onChange={onChange}
+          aria-invalid={!!errors.date}
+          className={inputStyles()}
+        />
+        {errors.date && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.date}
+          </p>
+        )}
+      </label>
+      <label className="block" htmlFor="time">
+        <span className="mb-1 block text-platinum">Preferred Time</span>
+        <input
+          id="time"
+          name="time"
+          type="time"
+          disabled={!requestAppointment}
+          required={requestAppointment}
+          value={formData.time}
+          onChange={onChange}
+          aria-invalid={!!errors.time}
+          className={inputStyles()}
+        />
+        {errors.time && (
+          <p role="alert" className="mt-1 text-sm text-red-500">
+            {errors.time}
+          </p>
+        )}
+      </label>
+      {!requestAppointment && (
+        <p className="text-xs italic text-platinum">
+          Enable appointment request above to choose date and time.
+        </p>
+      )}
+    </fieldset>
+  );
+}

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import ContactFields from './ContactFields';
+import { inputStyles } from './variants';
+
+export default function ContactForm({ onSuccess }) {
+  const [requestAppointment, setRequestAppointment] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    documentCategory: '',
+    appointmentType: '',
+    date: '',
+    time: '',
+    message: '',
+  });
+  const [errors, setErrors] = useState({});
+
+  const validate = () => {
+    const newErrors = {};
+    if (!formData.name.trim()) {
+      newErrors.name = 'Full name is required.';
+    }
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email address is required.';
+    } else if (!/\S+@\S+\.\S+/.test(formData.email)) {
+      newErrors.email = 'Enter a valid email address.';
+    }
+    if (!formData.documentCategory) {
+      newErrors.documentCategory = 'Document category is required.';
+    }
+    if (!formData.message.trim()) {
+      newErrors.message = 'Message is required.';
+    }
+    if (requestAppointment) {
+      if (!formData.appointmentType) {
+        newErrors.appointmentType = 'Appointment type is required.';
+      }
+      if (!formData.date) {
+        newErrors.date = 'Preferred date is required.';
+      }
+      if (!formData.time) {
+        newErrors.time = 'Preferred time is required.';
+      }
+    }
+    return newErrors;
+  };
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData({ ...formData, [name]: value });
+    if (errors[name]) {
+      setErrors({ ...errors, [name]: '' });
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const validation = validate();
+    if (Object.keys(validation).length > 0) {
+      setErrors(validation);
+      return;
+    }
+    setErrors({});
+    onSuccess();
+  };
+
+  return (
+    <>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        Contact Us
+      </h1>
+      <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+        <ContactFields
+          formData={formData}
+          errors={errors}
+          onChange={handleChange}
+          requestAppointment={requestAppointment}
+          setRequestAppointment={setRequestAppointment}
+          setErrors={setErrors}
+        />
+        <label className="block" htmlFor="message">
+          <span className="mb-1 block text-platinum">Message</span>
+          <textarea
+            id="message"
+            name="message"
+            required
+            rows="4"
+            value={formData.message}
+            onChange={handleChange}
+            aria-invalid={!!errors.message}
+            className={inputStyles()}
+          />
+          {errors.message && (
+            <p role="alert" className="mt-1 text-sm text-red-500">
+              {errors.message}
+            </p>
+          )}
+        </label>
+        <button
+          type="submit"
+          className="cta-button hover:border-silver hover:text-silver"
+        >
+          Send Message
+        </button>
+      </form>
+      <p className="text-sm italic text-platinum">
+        Submitting this form does not guarantee an appointment. All requests are
+        subject to confirmation by Keystone Notary Group, LLC.
+      </p>
+      <p className="text-xs text-platinum">
+        Keystone Notary Group, LLC is not a law firm and does not provide legal
+        advice or services. Please consult an attorney for legal questions or
+        document preparation.
+      </p>
+    </>
+  );
+}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -8,6 +8,7 @@ export default function Footer() {
         <a href="/about" aria-label="Footer link to About" className="hover:text-silver">About</a>
         <a href="/services" aria-label="Footer link to Services" className="hover:text-silver">Services</a>
         <a href="/prices" aria-label="Footer link to Prices" className="hover:text-silver">Prices</a>
+        <a href="/contact" aria-label="Footer link to Contact" className="hover:text-silver">Contact</a>
       </nav>
       <p className="mb-2">
         <a href="tel:2673099000" className="hover:text-silver">
@@ -22,10 +23,42 @@ export default function Footer() {
         </a>
       </p>
       <p className="mb-2 flex justify-center gap-3">
-        {/* Social icon placeholders */}
-        <span aria-hidden="true" className="h-5 w-5 rounded-full bg-deepgray" />
-        <span aria-hidden="true" className="h-5 w-5 rounded-full bg-deepgray" />
-        <span aria-hidden="true" className="h-5 w-5 rounded-full bg-deepgray" />
+        <a
+          href="https://twitter.com"
+          aria-label="Twitter"
+          className="text-platinum transition-colors hover:text-silver"
+        >
+          <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+            <path
+              d="M8 19c7.732 0 11.946-6.415 11.946-11.986 0-.18 0-.357-.012-.534A8.55 8.55 0 0022 4.308a8.19 8.19 0 01-2.357.65A4.1 4.1 0 0021.448 3.4a8.238 8.238 0 01-2.605.998A4.093 4.093 0 0015.448 3c-2.266 0-4.103 1.847-4.103 4.123 0 .322.036.636.106.936A11.623 11.623 0 013 4.784a4.128 4.128 0 00-.555 2.074c0 1.43.721 2.693 1.817 3.432a4.07 4.07 0 01-1.858-.514v.052c0 2.002 1.417 3.673 3.297 4.053a4.083 4.083 0 01-1.853.07c.523 1.646 2.041 2.845 3.838 2.877A8.208 8.208 0 012 17.558 11.616 11.616 0 008 19z"
+              fill="currentColor"
+            />
+          </svg>
+        </a>
+        <a
+          href="https://facebook.com"
+          aria-label="Facebook"
+          className="text-platinum transition-colors hover:text-silver"
+        >
+          <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+            <path
+              d="M15 2h4a1 1 0 011 1v4a1 1 0 01-1 1h-2c-.55 0-1 .45-1 1v2h3a1 1 0 011 1v4a1 1 0 01-1 1h-3v6a1 1 0 01-1 1h-4a1 1 0 01-1-1v-6H8a1 1 0 01-1-1v-4a1 1 0 011-1h3V9c0-2.761 2.239-5 5-5z"
+              fill="currentColor"
+            />
+          </svg>
+        </a>
+        <a
+          href="https://linkedin.com"
+          aria-label="LinkedIn"
+          className="text-platinum transition-colors hover:text-silver"
+        >
+          <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+            <path
+              d="M4.98 3.5c0 1.381-1.105 2.5-2.48 2.5A2.49 2.49 0 010 3.5C0 2.119 1.105 1 2.5 1S5 2.119 5 3.5zm.02 4.5H0V21h5V8zM8 8h4.75v1.945h.065c.663-1.258 2.286-2.445 4.705-2.445C21.507 7.5 23 9.715 23 13.167V21h-5v-6.667c0-1.588-.56-2.671-1.96-2.671-1.07 0-1.707.722-1.99 1.421-.102.249-.127.596-.127.942V21H9V8z"
+              fill="currentColor"
+            />
+          </svg>
+        </a>
       </p>
       <p>&copy; {new Date().getFullYear()} Keystone Notary Group, LLC. All rights reserved.</p>
     </footer>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -8,7 +8,9 @@ const navItems = [
   { name: "Home", path: "/" },
   { name: "About", path: "/about" },
   { name: "Services", path: "/services" },
+  { name: "Prices", path: "/prices" },
   { name: "FAQ", path: "/faq" },
+  { name: "Contact", path: "/contact" },
 ];
 
 export default function Navbar() {

--- a/src/components/ThankYou.jsx
+++ b/src/components/ThankYou.jsx
@@ -1,0 +1,12 @@
+export default function ThankYou() {
+  return (
+    <>
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        Thank You
+      </h1>
+      <p className="text-lg text-platinum">
+        Your message has been received. We will be in touch soon.
+      </p>
+    </>
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -10,3 +10,6 @@ export { default as StructuredData } from './StructuredData';
 export { default as PhoneIcon } from './PhoneIcon';
 export { default as SEO } from './SEO';
 export { default as ChatWidget } from './ChatWidget';
+export { default as ContactForm } from './ContactForm';
+export { default as ContactFields } from './ContactFields';
+export { default as ThankYou } from './ThankYou';

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { MotionSection, SEO } from '../components';
+import ContactForm from '../components/ContactForm';
+import ThankYou from '../components/ThankYou';
+
+export default function Contact() {
+  const [submitted, setSubmitted] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.hash) {
+      const id = location.hash.substring(1);
+      const el = document.getElementById(id);
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [location]);
+
+  if (submitted) {
+    return (
+      <MotionSection className="container space-y-6 py-20">
+        <SEO
+          title="Contact Keystone Notary Group | Schedule a Notary"
+          description="Request a mobile notary appointment or ask questions through our contact form."
+          path="/contact"
+        />
+        <ThankYou />
+      </MotionSection>
+    );
+  }
+
+  return (
+    <MotionSection id="contact" className="container space-y-8 py-8">
+      <SEO
+        title="Contact Keystone Notary Group | Schedule a Notary"
+        description="Request a mobile notary appointment or ask questions through our contact form."
+        path="/contact"
+      />
+      <ContactForm onSuccess={() => setSubmitted(true)} />
+    </MotionSection>
+  );
+}

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -91,7 +91,7 @@ export default function Services() {
           {services.map(({ title, desc, icon }) => (
             <li
               key={title}
-              className="rounded border border-platinum bg-deepgray p-4 shadow-sm transition-colors hover:bg-charcoal hover:shadow-lg"
+              className="rounded border border-platinum bg-deepgray p-4 shadow-sm transition-transform transition-colors hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg"
             >
               <div className="flex items-center gap-2">
                 {icon}


### PR DESCRIPTION
## Summary
- restore full Contact page with form and confirmation
- reintroduce ContactForm and helpers with input variants
- add Contact link across navbar and footer
- include social icons in footer
- animate service cards
- add regression test for Contact page

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_68702db8eab48327a86fdfc72b61d9d4