### PR TITLE
Implement mobile swipe navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1",
+        "react-swipeable": "^7.0.2",
         "tailwind-variants": "^1.0.0",
         "zod": "^3.25.76"
       },
@@ -2900,9 +2901,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.181",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.181.tgz",
-      "integrity": "sha512-+ISMj8OIQ+0qEeDj14Rt8WwcTOiqHyAB+5bnK1K7xNNLjBJ4hRCQfUkw8RWtcLbfBzDwc15ZnKH0c7SNOfwiyA==",
+      "version": "1.5.182",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
+      "integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5721,6 +5722,15 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-swipeable": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
+      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1",
+    "react-swipeable": "^7.0.2",
     "tailwind-variants": "^1.0.0",
     "zod": "^3.25.76"
   },

--- a/src/__tests__/Navigation.test.jsx
+++ b/src/__tests__/Navigation.test.jsx
@@ -10,8 +10,22 @@ function setup() {
   );
 }
 
+beforeEach(() => {
+  Object.defineProperty(navigator, 'maxTouchPoints', { configurable: true, value: 1 });
+});
+
 test('navigates to about page', () => {
   setup();
   fireEvent.click(screen.getAllByRole('link', { name: /^about$/i })[0]);
   expect(screen.getByRole('heading', { name: /about us/i })).toBeInTheDocument();
 });
+
+test('swipe left from home navigates to about page', async () => {
+  setup();
+  const main = screen.getByRole('main');
+  fireEvent.touchStart(main, { touches: [{ clientX: 200, clientY: 0 }] });
+  fireEvent.touchMove(main, { touches: [{ clientX: 50, clientY: 0 }] });
+  fireEvent.touchEnd(main, { changedTouches: [{ clientX: 10, clientY: 0 }] });
+  expect(await screen.findByRole('heading', { name: /about us/i })).toBeInTheDocument();
+});
+

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,5 +1,7 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
+import { useSwipeable } from 'react-swipeable';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import ScrollToTopButton from './ScrollToTopButton';
@@ -8,6 +10,36 @@ import ChatWidget from './ChatWidget';
 
 export default function Layout() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const [direction, setDirection] = useState(0);
+
+  // Define page order to allow sequential navigation via swipes
+  const pages = ['/', '/about', '/services', '/faq', '/prices', '/contact'];
+  const index = pages.indexOf(location.pathname);
+
+  function goNext() {
+    if (index === -1) return;
+    const nextIndex = (index + 1) % pages.length;
+    setDirection(-1); // Slide left when moving forward
+    navigate(pages[nextIndex]);
+  }
+
+  function goPrev() {
+    if (index === -1) return;
+    const prevIndex = (index - 1 + pages.length) % pages.length;
+    setDirection(1); // Slide right when moving backward
+    navigate(pages[prevIndex]);
+  }
+
+  const isTouch = typeof window !== 'undefined' &&
+    ('ontouchstart' in window || navigator.maxTouchPoints > 0);
+  const handlers = useSwipeable({ onSwipedLeft: goNext, onSwipedRight: goPrev });
+
+  const variants = {
+    enter: (dir) => ({ x: dir > 0 ? -50 : 50, opacity: 0 }),
+    center: { x: 0, opacity: 1 },
+    exit: (dir) => ({ x: dir > 0 ? 50 : -50, opacity: 0 }),
+  };
 
   return (
     <>
@@ -21,13 +53,17 @@ export default function Layout() {
           Skip to content
         </a>
         <Navbar />
-        <AnimatePresence mode="wait">
+        <AnimatePresence mode="wait" custom={direction}>
           <motion.main
             key={location.pathname}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.3 }}
+            {...(isTouch ? handlers : {})}
+            variants={variants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            custom={direction}
+            transition={{ type: 'tween', duration: 0.3 }}
+            onAnimationComplete={() => setDirection(0)}
             id="content"
             className="flex-grow pt-16"
           >


### PR DESCRIPTION
## Summary
- add react-swipeable for gesture detection
- enable swipe-based navigation in `Layout`
- test left-swipe navigation

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_68703ffc9dac832796d536b1ceeefd86