### PR TITLE
Improve mobile swipe navigation

### DIFF
--- a/src/__tests__/Navigation.test.jsx
+++ b/src/__tests__/Navigation.test.jsx
@@ -37,3 +37,12 @@ test('page indicator reflects current page and supports navigation', async () =>
   expect(await screen.findByRole('heading', { name: /^services$/i })).toBeInTheDocument();
 });
 
+test('vertical scrolling does not trigger navigation', () => {
+  setup();
+  const main = screen.getByRole('main');
+  fireEvent.touchStart(main, { touches: [{ clientX: 100, clientY: 0 }] });
+  fireEvent.touchMove(main, { touches: [{ clientX: 100, clientY: 50 }] });
+  fireEvent.touchEnd(main, { changedTouches: [{ clientX: 100, clientY: 100 }] });
+  expect(screen.queryByRole('heading', { name: /about us/i })).not.toBeInTheDocument();
+});
+

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -13,6 +13,7 @@ export default function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
   const [direction, setDirection] = useState(0);
+  const [showIndicator, setShowIndicator] = useState(true);
 
   // Define page order to allow sequential navigation via swipes
   const pages = ['/', '/about', '/services', '/faq', '/prices', '/contact'];
@@ -22,6 +23,7 @@ export default function Layout() {
     if (index === -1) return;
     const nextIndex = (index + 1) % pages.length;
     setDirection(-1); // Slide left when moving forward
+    setShowIndicator(false);
     navigate(pages[nextIndex]);
   }
 
@@ -29,12 +31,14 @@ export default function Layout() {
     if (index === -1) return;
     const prevIndex = (index - 1 + pages.length) % pages.length;
     setDirection(1); // Slide right when moving backward
+    setShowIndicator(false);
     navigate(pages[prevIndex]);
   }
 
   function goTo(i) {
     if (i === index || index === -1) return;
     setDirection(i > index ? -1 : 1);
+    setShowIndicator(false);
     navigate(pages[i]);
   }
 
@@ -42,7 +46,8 @@ export default function Layout() {
     onSwipedLeft: goNext,
     onSwipedRight: goPrev,
     trackMouse: true,
-    delta: 40,
+    delta: 80,
+    preventScrollOnSwipe: false,
   });
 
   const variants = {
@@ -72,15 +77,28 @@ export default function Layout() {
             animate="center"
             exit="exit"
             custom={direction}
-            transition={{ type: 'tween', duration: 0.35, ease: [0.4, 0, 0.2, 1] }}
-            onAnimationComplete={() => setDirection(0)}
+            transition={{ type: 'tween', duration: 0.4, ease: 'easeInOut' }}
+            onAnimationComplete={() => {
+              setDirection(0);
+              setShowIndicator(true);
+            }}
             id="content"
             className="flex-grow pt-16"
           >
             <Outlet />
           </motion.main>
         </AnimatePresence>
-        <PageIndicator pages={pages} current={index} onSelect={goTo} />
+        <AnimatePresence initial={false}>
+          {showIndicator && (
+            <PageIndicator
+              key={location.pathname}
+              pages={pages}
+              current={index}
+              onSelect={goTo}
+              className="fixed inset-x-0 bottom-10 pointer-events-none md:hidden"
+            />
+          )}
+        </AnimatePresence>
         <Footer />
         <ScrollToTopButton />
         <ChatWidget />

--- a/src/components/PageIndicator.jsx
+++ b/src/components/PageIndicator.jsx
@@ -1,9 +1,17 @@
+import { motion } from 'framer-motion';
 import clsx from 'clsx';
 
-export default function PageIndicator({ pages, current, onSelect }) {
+export default function PageIndicator({ pages, current, onSelect, className }) {
   return (
-    <nav aria-label="Page indicator" className="mt-4">
-      <ul className="flex items-center justify-center gap-2">
+    <motion.nav
+      aria-label="Page indicator"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 0.5 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.3, ease: 'easeInOut' }}
+      className={clsx(className)}
+    >
+      <ul className="pointer-events-auto flex items-center justify-center gap-2">
         {pages.map((page, i) => (
           <li key={page}>
             <button
@@ -20,6 +28,6 @@ export default function PageIndicator({ pages, current, onSelect }) {
           </li>
         ))}
       </ul>
-    </nav>
+    </motion.nav>
   );
 }


### PR DESCRIPTION
## Summary
- slow down page transition animation and ease with `ease-in-out`
- require stronger swipes and don’t block scrolling
- fade page indicator and float it above the footer
- prevent accidental page changes when scrolling

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_68704a3666108327a411b12da3989bb9