### PR TITLE
Improve swipe navigation with real-time drag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1",
-        "react-swipeable": "^7.0.2",
         "tailwind-variants": "^1.0.0",
         "zod": "^3.25.76"
       },
@@ -5722,15 +5721,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-swipeable": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-7.0.2.tgz",
-      "integrity": "sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1",
-    "react-swipeable": "^7.0.2",
     "tailwind-variants": "^1.0.0",
     "zod": "^3.25.76"
   },

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,7 +1,6 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Outlet, useLocation, useNavigate } from 'react-router-dom';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useSwipeable } from 'react-swipeable';
+import { AnimatePresence, motion, useMotionValue, animate } from 'framer-motion';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import ScrollToTopButton from './ScrollToTopButton';
@@ -42,18 +41,93 @@ export default function Layout() {
     navigate(pages[i]);
   }
 
-  const handlers = useSwipeable({
-    onSwipedLeft: goNext,
-    onSwipedRight: goPrev,
-    trackMouse: true,
-    delta: 80,
-    preventScrollOnSwipe: false,
+
+  // Track horizontal drag offset in real time
+  const dragX = useMotionValue(0);
+  const dragState = useRef({
+    startX: 0,
+    startY: 0,
+    time: 0,
+    dragging: false,
+    horizontal: false,
   });
 
+  // Normalize pointer and touch events to get client coordinates
+  function point(event) {
+    if ('touches' in event && event.touches.length) return event.touches[0];
+    if ('changedTouches' in event && event.changedTouches.length)
+      return event.changedTouches[0];
+    return event;
+  }
+
+  // Start tracking on pointer down to later decide if it's a swipe or scroll
+  function handleStart(event) {
+    const p = point(event);
+    dragState.current = {
+      startX: p.clientX,
+      startY: p.clientY,
+      time: event.timeStamp,
+      dragging: true,
+      horizontal: false,
+    };
+  }
+
+  // Update motion value during horizontal drag; cancel if user scrolls vertically
+  function handleMove(event) {
+    const state = dragState.current;
+    if (!state.dragging) return;
+    const p = point(event);
+    const dx = p.clientX - state.startX;
+    const dy = p.clientY - state.startY;
+    if (!state.horizontal) {
+      if (Math.abs(dx) > 10 && Math.abs(dx) > Math.abs(dy)) {
+        state.horizontal = true;
+      } else if (Math.abs(dy) > 10) {
+        // User moved more vertically than horizontally, allow scrolling
+        state.dragging = false;
+        return;
+      }
+    }
+    if (state.horizontal) {
+      // Prevent vertical scrolling once horizontal intent is confirmed
+      event.preventDefault();
+      dragX.set(dx);
+    }
+  }
+
+  // On release, decide whether to navigate or snap back based on distance/speed
+  function handleEnd(event) {
+    const state = dragState.current;
+    if (!state.dragging && !state.horizontal) return;
+    const p = point(event);
+    const dx = p.clientX - state.startX;
+    const dt = event.timeStamp - state.time;
+    const velocity = dx / dt;
+    state.dragging = false;
+    const threshold = 80;
+    const speed = 0.5;
+    if (state.horizontal && (Math.abs(dx) > threshold || Math.abs(velocity) > speed)) {
+      const dir = dx < 0 ? -1 : 1;
+      // Continue motion off screen before navigating to the next page
+      animate(dragX, dir * window.innerWidth, {
+        type: 'spring',
+        stiffness: 260,
+        damping: 30,
+        duration: 0.35,
+      }).then(() => {
+        dir < 0 ? goNext() : goPrev();
+        dragX.set(0);
+      });
+    } else {
+      // Not enough momentum: return to starting position
+      animate(dragX, 0, { type: 'spring', stiffness: 300, damping: 30, duration: 0.35 });
+    }
+  }
+
   const variants = {
-    enter: (dir) => ({ x: dir > 0 ? -30 : 30, opacity: 0 }),
+    enter: (dir) => ({ x: dir > 0 ? -window.innerWidth : window.innerWidth, opacity: 0 }),
     center: { x: 0, opacity: 1 },
-    exit: (dir) => ({ x: dir > 0 ? 30 : -30, opacity: 0 }),
+    exit: (dir) => ({ x: dir > 0 ? window.innerWidth : -window.innerWidth, opacity: 0 }),
   };
 
   return (
@@ -71,7 +145,13 @@ export default function Layout() {
         <AnimatePresence mode="wait" custom={direction}>
           <motion.main
             key={location.pathname}
-            {...handlers}
+            onPointerDown={handleStart}
+            onPointerMove={handleMove}
+            onPointerUp={handleEnd}
+            onTouchStart={handleStart}
+            onTouchMove={handleMove}
+            onTouchEnd={handleEnd}
+            style={{ x: dragX }}
             variants={variants}
             initial="enter"
             animate="center"


### PR DESCRIPTION
## Summary
- implement pointer-based swipe logic with live drag offset
- add spring animations for snapping or bounce back
- remove react-swipeable dependency

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68704d672a708327a846d79955735826