### PR TITLE
Fix credentials header underline

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -22,7 +22,7 @@ export default function Credentials({ className = '' }) {
       <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-8">
         <h2
           id="credentials-heading"
-          className="text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+          className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
         >
           Credentials
         </h2>


### PR DESCRIPTION
## Summary
- extend credentials heading underline across entire section
- keep consistent with other section headers

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687118181b5c8327a71129f21012e86a