### PR TITLE
Update CTA button color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@
   }
 
   .cta-button {
-    @apply relative inline-block rounded border border-platinum bg-gradient-to-br from-accent to-deepgray px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-accent hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
+    @apply relative inline-block rounded border border-platinum bg-gradient-to-br from-accentDark to-deepgray px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-accentDark hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
     /* Add focus ring to ensure keyboard users can see button focus */
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
         platinum: '#999999',
         silver: '#bfbfbf',
         accent: '#2aa198',
+        accentDark: '#1d716a',
       },
       container: {
         center: true,


### PR DESCRIPTION
## Summary
- darken call-to-action buttons with brand color `accentDark`
- expose `accentDark` in Tailwind config

## Testing
- `yarn build`
- `yarn test:run`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_68717044f20c8327b6a17e86e099231a