### PR TITLE
Enhance hero logo depth

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -31,13 +31,14 @@ export default function Hero() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.6 }}
+            className="logo-wrapper mx-auto mb-6 mt-6 drop-shadow-xl"
           >
             <img
               src="/hero-logo.PNG"
               alt="Keystone Notary Group logo on parchment"
               width="1024"
               height="1024"
-              className="mx-auto mb-6 mt-6 h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem] drop-shadow-lg"
+              className="h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem]"
               draggable={false}
             />
           </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -103,6 +103,19 @@
     z-index: 1;
   }
 
+  /* Dark radial fade so parchment edges blend into the hero background */
+  .logo-wrapper {
+    @apply relative inline-block rounded-lg;
+  }
+  .logo-wrapper::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: radial-gradient(circle at center, rgba(0,0,0,0) 60%, rgba(0,0,0,0.7));
+  }
+
   .footer-gradient {
     @apply relative;
   }


### PR DESCRIPTION
## Summary
- add dark radial fade around hero logo
- wrap logo image in `.logo-wrapper` for depth

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6871b8310dac8327ad4d0d6899a71055