### PR TITLE
Fix logo edge glow

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -38,7 +38,7 @@ export default function Hero() {
               alt="Keystone Notary Group logo on parchment"
               width="1024"
               height="1024"
-              className="h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem]"
+              className="h-auto w-72 max-w-full mix-blend-multiply mask-side-fade sm:w-80 md:w-96 lg:w-[30rem]"
               draggable={false}
             />
           </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -113,7 +113,13 @@
     inset: 0;
     border-radius: inherit;
     pointer-events: none;
-    background: radial-gradient(circle at center, rgba(0,0,0,0) 60%, rgba(0,0,0,0.7));
+    background: radial-gradient(circle at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.8) 90%);
+  }
+
+  /* Fade the left and right edges so parchment blends into hero background */
+  .mask-side-fade {
+    -webkit-mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
+    mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
   }
 
   .footer-gradient {


### PR DESCRIPTION
## Summary
- darken edges of parchment logo so it blends better with the hero background
- fade sides of hero logo to eliminate stray glow

## Testing
- `yarn lint && echo "lint ok"`
- `yarn test:run`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_6871ba3002c08327ba4d568896ddac11