### PR TITLE
Fix chat bubble layering and update FAQ link

### DIFF
--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -111,7 +111,7 @@ export default function ChatWidget() {
           <motion.button
             key="bubble"
             onClick={() => setOpen(true)}
-            className="fixed bottom-4 right-4 rounded-full bg-deepgray px-4 py-2 text-white shadow-lg transition-colors hover:bg-charcoal focus:outline-none focus:ring focus:ring-platinum"
+            className="fixed bottom-4 right-4 z-50 rounded-full bg-deepgray px-4 py-2 text-white shadow-lg transition-colors hover:bg-charcoal focus:outline-none focus:ring focus:ring-platinum"
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             initial={reduce ? false : { opacity: 0, scale: 0.8 }}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -130,9 +130,9 @@ export default function Navbar() {
       <AnimatePresence>
         {open && (
           <motion.div
-            className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm nav:hidden"
+            className="fixed inset-0 z-40 bg-black/90 backdrop-blur-sm nav:hidden"
             initial={{ opacity: 0 }}
-            animate={{ opacity: 0.7 }}
+            animate={{ opacity: 0.9 }}
             exit={{ opacity: 0 }}
           >
             <button
@@ -146,7 +146,7 @@ export default function Navbar() {
               ref={menuRef}
               aria-label="Mobile navigation"
               onMouseDown={(e) => e.stopPropagation()}
-              className="ml-auto h-full w-full max-w-xs sm:max-w-sm bg-black/80 backdrop-blur-lg border-l border-white/20 p-6 shadow-xl"
+              className="ml-auto h-full w-full max-w-xs sm:max-w-sm bg-black/90 backdrop-blur-lg border-l border-white/20 p-6 shadow-xl"
               initial="closed"
               animate="open"
               exit="closed"

--- a/src/components/ScrollToTopButton.jsx
+++ b/src/components/ScrollToTopButton.jsx
@@ -25,7 +25,7 @@ export default function ScrollToTopButton() {
           transition={{ duration: 0.3 }}
           onClick={handleClick}
           aria-label="Scroll to top"
-          className="fixed bottom-4 right-4 rounded-full bg-deepgray p-3 text-white transition hover:text-silver shadow-lg focus:outline-none focus:ring focus:ring-platinum"
+          className="fixed bottom-4 right-4 z-40 rounded-full bg-deepgray p-3 text-white transition hover:text-silver shadow-lg focus:outline-none focus:ring focus:ring-platinum"
         >
           ↑
         </motion.button>

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -112,7 +112,7 @@ export default function FAQ() {
         </ul>
         <p className="mt-4 text-platinum">
           Still have questions?{' '}
-          <Link to="/" className="underline hover:text-silver">
+          <Link to="/contact" className="underline hover:text-silver">
             Contact us
           </Link>
           .


### PR DESCRIPTION
## Summary
- keep chat widget bubble above other fixed elements
- darken mobile navigation overlay for readability
- ensure scroll-to-top button doesn't overlap chat widget
- correct FAQ contact link to `/contact`

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_6871e935960c832799bc197ca9a30e94