### PR TITLE
Refine menu and button styling

### DIFF
--- a/src/components/HamburgerIcon.jsx
+++ b/src/components/HamburgerIcon.jsx
@@ -1,0 +1,14 @@
+export default function HamburgerIcon({ className }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M3 6h18M3 12h18M3 18h18" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,6 +3,7 @@ import { Link, NavLink } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
 import clsx from "clsx";
 import { navLinkStyles } from "./variants";
+import HamburgerIcon from "./HamburgerIcon";
 
 // Animation variants for the sliding mobile menu
 const menuVariants = {
@@ -97,15 +98,13 @@ export default function Navbar() {
           <span className="nav:hidden whitespace-nowrap">Keystone Notary</span>
         </Link>
         <button
-          className="nav:hidden flex flex-col items-center justify-center p-2 focus:outline-none focus:ring-2 focus:ring-platinum"
+          className="nav:hidden flex items-center justify-center p-2 focus:outline-none focus:ring-2 focus:ring-platinum"
           /* Focus ring ensures mobile menu trigger is keyboard accessible */
           onClick={toggle}
           aria-label="Toggle navigation"
           aria-expanded={open}
         >
-          <span className="mb-1 block h-0.5 w-6 bg-platinum transition-colors hover:bg-silver" />
-          <span className="mb-1 block h-0.5 w-6 bg-platinum transition-colors hover:bg-silver" />
-          <span className="block h-0.5 w-6 bg-platinum transition-colors hover:bg-silver" />
+          <HamburgerIcon className="h-6 w-6 text-platinum transition-colors hover:text-silver" />
         </button>
         <ul className="hidden items-center gap-3 nav:flex">
           {navItems.map((item) => (
@@ -160,7 +159,7 @@ export default function Navbar() {
                 ✕
               </button>
               <motion.ul
-                className="mt-8 flex flex-col gap-4"
+                className="mt-8 flex flex-col divide-y divide-platinum/20 border-t border-platinum/20"
                 variants={{ open: { transition: { staggerChildren: 0.05 } } }}
               >
                 {navItems.map((item) => (

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ export { default as Navbar } from './Navbar';
 export { default as ScrollToTopButton } from './ScrollToTopButton';
 export { default as StructuredData } from './StructuredData';
 export { default as PhoneIcon } from './PhoneIcon';
+export { default as HamburgerIcon } from './HamburgerIcon';
 export { default as SEO } from './SEO';
 export { default as ChatWidget } from './ChatWidget';
 export { default as ContactForm } from './ContactForm';

--- a/src/index.css
+++ b/src/index.css
@@ -25,8 +25,8 @@
   }
 
   .cta-button {
-    @apply relative inline-block rounded border border-platinum bg-gradient-to-br from-accentDark to-deepgray px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-accentDark hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
-    /* Add focus ring to ensure keyboard users can see button focus */
+    @apply relative inline-block rounded border border-platinum bg-gradient-to-br from-accent via-accentDark to-deepgray px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-accentDark hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
+    /* Buttons use a gold gradient for a more luxurious feel */
   }
 
   @keyframes cta-glow {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,8 +21,8 @@ export default {
         deepgray: '#1A1A1A',
         platinum: '#999999',
         silver: '#bfbfbf',
-        accent: '#2aa198',
-        accentDark: '#1d716a',
+        accent: '#d4af37',
+        accentDark: '#b8860b',
       },
       // Limit container width for consistent layouts across large screens
       container: {


### PR DESCRIPTION
## Summary
- create `HamburgerIcon` and use it in the navbar
- tighten up mobile menu spacing
- shift accent colors to gold for brand alignment

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6871efeffa688327adb4186a6a263802