### PR TITLE
Align website palette with brand silver tones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,14 @@ To book a notary, email [info@keystonenotarygroup.com](mailto:info@keystonenotar
 For urgent matters, call the phone number listed on the site to check availability. We look forward to assisting with your notarization needs.
 
 Our website now features a streamlined layout optimized for mobile devices, so you can schedule appointments quickly from any screen size.
+
+## Brand Guidelines
+
+The Keystone brand uses a restrained palette built around charcoal, black, and varying shades of gray. Primary colors include:
+
+- **Charcoal** `#121212`
+- **Deep Gray** `#1A1A1A`
+- **Platinum Gray** `#999999`
+- **Silver** `#bfbfbf`
+
+Metallic silver accents are allowed, but gold or other hues should not be introduced. Designs should feel minimalist and professional—mirroring our charcoal matte business cards with silver foil logos. All website updates should maintain this luxurious, monochromatic style.

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -78,7 +78,7 @@ export default function Hero() {
         </p>
         <a
           href="#why-heading"
-          className="scroll-hint mt-4 text-silver focus:outline-none focus:ring-2 focus:ring-accent"
+          className="scroll-hint mt-4 text-silver focus:outline-none focus:ring-2 focus:ring-silver"
           aria-label="Scroll for more"
         >
           <span aria-hidden="true">↓</span>

--- a/src/index.css
+++ b/src/index.css
@@ -25,8 +25,8 @@
   }
 
   .cta-button {
-    @apply relative inline-block rounded border border-platinum bg-gradient-to-br from-accent via-accentDark to-deepgray px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-accentDark hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
-    /* Buttons use a gold gradient for a more luxurious feel */
+    @apply relative inline-block rounded border border-silver bg-gradient-to-br from-accentDark via-deepgray to-black px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-silver hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
+    /* Buttons use a dark silver gradient for readability */
   }
 
   @keyframes cta-glow {

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -72,7 +72,7 @@ export default function FAQ() {
                 aria-expanded={isOpen}
                 aria-controls={`faq-panel-${idx}`}
                 id={`faq-header-${idx}`}
-                className="flex w-full items-center justify-between bg-deepgray px-4 py-4 text-left text-platinum transition-colors hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                className="flex w-full items-center justify-between bg-deepgray px-4 py-4 text-left text-platinum transition-colors hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-silver"
               >
                 <span className="font-medium">{q}</span>
                 <svg

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -7,7 +7,7 @@ export default function Services() {
       desc:
         'Official witnessing of signatures, affirmations, and acknowledgements as required by Pennsylvania law.',
       icon: (
-        <svg viewBox="0 0 24 24" className="h-6 w-6 text-accent" aria-hidden="true">
+        <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
           <path
             d="M5 13l4 4L19 7"
             fill="none"
@@ -23,7 +23,7 @@ export default function Services() {
       title: 'Loan Signing Services',
       desc: 'Professional handling of mortgage closings and refinance packages.',
       icon: (
-        <svg viewBox="0 0 24 24" className="h-6 w-6 text-accent" aria-hidden="true">
+        <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
           <path
             d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"
             fill="none"
@@ -40,7 +40,7 @@ export default function Services() {
       desc:
         'Provide notary services outside regular business hours or on short notice, subject to availability and applicable surcharges.',
       icon: (
-        <svg viewBox="0 0 24 24" className="h-6 w-6 text-accent" aria-hidden="true">
+        <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
           <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" fill="none" />
           <path d="M12 6v6l3 3" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
         </svg>
@@ -51,7 +51,7 @@ export default function Services() {
       desc:
         'Administer legally binding oaths and affirmations for affidavits, statements, and declarations.',
       icon: (
-        <svg viewBox="0 0 24 24" className="h-6 w-6 text-accent" aria-hidden="true">
+        <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
           <path
             d="M12 6v6l3 3"
             stroke="currentColor"
@@ -68,7 +68,7 @@ export default function Services() {
       desc:
         'Certify copies of documents as true and accurate representations of the original when allowed by law.',
       icon: (
-        <svg viewBox="0 0 24 24" className="h-6 w-6 text-accent" aria-hidden="true">
+        <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
           <rect x="3" y="3" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2" fill="none" />
           <path d="M3 9h18M9 21V9" stroke="currentColor" strokeWidth="2" fill="none" />
         </svg>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,8 +21,8 @@ export default {
         deepgray: '#1A1A1A',
         platinum: '#999999',
         silver: '#bfbfbf',
-        accent: '#d4af37',
-        accentDark: '#b8860b',
+        accent: '#bfbfbf',
+        accentDark: '#333333',
       },
       // Limit container width for consistent layouts across large screens
       container: {


### PR DESCRIPTION
## Summary
- clarify color palette and guidelines in `AGENTS.md`
- update Tailwind theme to use silver accent colors
- restyle CTA button with a dark silver gradient
- adjust focus rings and service icons to match new scheme

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6871f408b11083279ad6014e2b764a4d