### PR TITLE
Refine navbar alignment

### DIFF
--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -60,8 +60,10 @@ describe("Navbar component", () => {
         <Navbar />
       </MemoryRouter>,
     );
-    const toggleWrapper = screen.getByRole("button", { name: /toggle navigation/i }).parentElement;
-    expect(toggleWrapper).toHaveClass("landscape-toggle");
+    const toggleButton = screen.getByRole("button", {
+      name: /toggle navigation/i,
+    });
+    expect(toggleButton).toHaveClass("landscape-toggle");
     const brand = screen.getByRole("link", { name: /keystone notary group, llc/i });
     expect(brand).toHaveClass("landscape-brand");
     const list = screen.getByRole("list");

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -112,17 +112,17 @@ export default function Navbar() {
         scrolled && "shadow-md",
       )}
     >
-      <nav className="mx-auto grid max-w-5xl grid-cols-[1fr_auto_1fr] items-center px-4 py-3 sm:px-6 md:py-4">
-        <div className="col-start-3 flex justify-self-end md:hidden landscape-toggle">
-          <button
-            onClick={toggle}
-            aria-label="Toggle navigation"
-            aria-expanded={open}
-            className="flex items-center justify-center p-2 focus:outline-none focus:ring-2 focus:ring-platinum"
-          >
-            <GridIcon className="h-6 w-6 text-platinum transition-colors hover:text-silver" />
-          </button>
-        </div>
+      <nav
+        className="mx-auto grid max-w-5xl grid-cols-[1fr_auto_1fr] items-center gap-x-4 px-4 py-3 sm:px-8 sm:py-4"
+      >
+        <button
+          onClick={toggle}
+          aria-label="Toggle navigation"
+          aria-expanded={open}
+          className="col-start-3 flex justify-self-end md:hidden landscape-toggle items-center justify-center p-2 focus:outline-none focus:ring-2 focus:ring-platinum"
+        >
+          <GridIcon className="h-6 w-6 text-platinum transition-colors hover:text-silver" />
+        </button>
         <Link
           to="/"
           className="col-start-2 justify-self-center whitespace-nowrap rounded border border-transparent px-3 font-serif text-xl font-semibold text-white transition-colors hover:border-silver hover:text-silver landscape-brand"


### PR DESCRIPTION
## Summary
- streamline Navbar markup and align toggle on the far right
- adjust grid spacing for balanced header padding
- update Navbar tests to reflect markup changes

## Testing
- `npx eslint "src/**/*.{js,jsx}" -f unix`
- `yarn test:run`
- `yarn build`
- `yarn preview`

------
https://chatgpt.com/codex/tasks/task_b_6872279c926883278c0426d62e176d18