### PR TITLE
Fix hero logo blending and service text clipping

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -39,7 +39,7 @@ export default function Hero() {
               alt="Keystone Notary Group logo on parchment"
               width="1024"
               height="1024"
-              className="h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem]"
+              className="h-auto w-72 max-w-full mix-blend-multiply mask-side-fade sm:w-80 md:w-96 lg:w-[30rem]"
               draggable={false}
             />
           </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -112,6 +112,12 @@
     background: radial-gradient(circle at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.8) 90%);
   }
 
+  /* Fade the left and right edges so parchment blends into hero background */
+  .mask-side-fade {
+    -webkit-mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
+    mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
+  }
+
 
   .footer-gradient {
     @apply relative;

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -109,7 +109,7 @@ export default function Services() {
           {services.map(({ title, desc, icon }) => (
             <li
               key={title}
-              className="overflow-hidden rounded border border-platinum bg-deepgray p-4 shadow-sm transition-transform transition-colors hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg"
+              className="rounded border border-platinum bg-deepgray p-4 shadow-sm transition-transform transition-colors hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg"
             >
               <div className="flex items-center gap-2">
                 {icon}


### PR DESCRIPTION
## Summary
- blend hero logo edges with CSS mask
- prevent text clipping in services cards

## Testing
- `yarn lint`
- `yarn test:run`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_687265bd914c832784b3faad07197a0f