### PR TITLE
Remove hero logo shading and adjust service card text

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -32,14 +32,14 @@ export default function Hero() {
             initial={reduce ? false : { opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ duration: 0.6 }}
-            className="logo-wrapper mx-auto mb-6 mt-6 drop-shadow-xl"
+            className="logo-wrapper mx-auto mb-6 mt-6"
           >
             <img
               src="/hero-logo.PNG"
               alt="Keystone Notary Group logo on parchment"
               width="1024"
               height="1024"
-              className="h-auto w-72 max-w-full mix-blend-multiply mask-side-fade sm:w-80 md:w-96 lg:w-[30rem]"
+              className="h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem]"
               draggable={false}
             />
           </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -99,24 +99,11 @@
     z-index: 1;
   }
 
-  /* Dark radial fade so parchment edges blend into the hero background */
+  /* Wrapper remains for layout but no extra shading */
   .logo-wrapper {
     @apply relative inline-block rounded-lg;
   }
-  .logo-wrapper::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    pointer-events: none;
-    background: radial-gradient(circle at center, rgba(0,0,0,0) 50%, rgba(0,0,0,0.8) 90%);
-  }
 
-  /* Fade the left and right edges so parchment blends into hero background */
-  .mask-side-fade {
-    -webkit-mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
-    mask-image: linear-gradient(to right, transparent 0, black 5%, black 95%, transparent 100%);
-  }
 
 
   .footer-gradient {

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -113,9 +113,9 @@ export default function Services() {
             >
               <div className="flex items-center gap-2">
                 {icon}
-                <h2 className="text-xl font-semibold text-platinum">{title}</h2>
+                <h2 className="text-lg font-semibold text-platinum sm:text-xl">{title}</h2>
               </div>
-              <p className="mt-2 text-platinum">{desc}</p>
+              <p className="mt-2 text-sm text-platinum sm:text-base">{desc}</p>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary
- remove CSS gradient mask from hero logo
- drop shadow and blend modes removed on hero logo
- shrink service card fonts on small screens

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_b_68726fd9c4fc8327b949eb8f75545e52