### PR TITLE
Enable automated sitemap + robots

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build && cp dist/sitemap.xml public/sitemap.xml",
+    "build": "vite build",
     "preview": "vite preview",
     "test": "vitest --watch",
     "test:run": "vitest run",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://keystonenotarygroup.com/sitemap.xml

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
     react(),
     sitemap({
       hostname: 'https://keystonenotarygroup.com',
-      generateRobotsTxt: false,
+      generateRobotsTxt: true,
     }),
   ],
   // ⚠️ React Router v7 warnings already suppressed — do not re-add


### PR DESCRIPTION
## Summary
- generate `robots.txt` via vite-plugin-sitemap
- simplify build script
- remove static robots file

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687273a1cb148327bd618c6f0588e422