### PR TITLE
Fix missing gray hex codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,8 +45,8 @@ The Keystone brand uses a restrained palette built around charcoal, black, and v
 - **Charcoal** `#121212`
 - **Deep Gray** `#1A1A1A`
 - **Platinum Gray** `#999999`
-- **Light Gray** ``
-- **Medium Gray** ``
+- **Light Gray** `#CCCCCC`
+- **Medium Gray** `#666666`
 - **Silver** `#bfbfbf`
 - **Metallic Silver** ``
 


### PR DESCRIPTION
## Summary
- add hex codes for Light Gray and Medium Gray in Brand Guidelines

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_6872e833ec9c83278de252eb7ca9564c