### PR TITLE
Fix service card overflow

### DIFF
--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -109,7 +109,7 @@ export default function Services() {
           {services.map(({ title, desc, icon }) => (
             <li
               key={title}
-              className="rounded border border-platinum bg-deepgray p-4 shadow-sm transition-transform transition-colors hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg overflow-hidden"
+              className="rounded border border-platinum bg-deepgray p-4 shadow-sm transition-transform transition-colors hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg"
             >
               <div className="flex flex-wrap items-start gap-2">
                 {icon}


### PR DESCRIPTION
## Summary
- prevent service card text clipping by removing overflow hidden

## Testing
- `npm run test:run`
- `npm run lint`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_687340104d908327ac65806fc834d9bb