### PR TITLE
Fix service card overflow

### DIFF
--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -113,7 +113,7 @@ export default function Services() {
             >
               <div className="flex flex-wrap items-start gap-2">
                 {icon}
-                <h2 className="break-words text-lg font-semibold text-platinum sm:text-xl">{title}</h2>
+                <h2 className="min-w-0 break-words text-lg font-semibold text-platinum sm:text-xl">{title}</h2>
               </div>
               <p className="mt-2 break-words text-sm text-platinum sm:text-base">{desc}</p>
             </li>


### PR DESCRIPTION
## Summary
- ensure service headings shrink within card boundaries

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68734bfa754483278c4b26e40f09adbd