### PR TITLE
Refactor services layout with collapsible items

### DIFF
--- a/src/__tests__/Services.test.jsx
+++ b/src/__tests__/Services.test.jsx
@@ -19,14 +19,14 @@ test('renders services list with updated offerings', () => {
   expect(
     screen.getByRole('heading', { level: 1, name: /services/i })
   ).toBeInTheDocument();
-  // check for one of the new service titles
+  // check that service toggles render as buttons
   expect(
-    screen.getByRole('heading', { name: /after-hours & emergency notary/i })
+    screen.getByRole('button', { name: /after-hours & emergency notary/i })
   ).toBeInTheDocument();
   expect(
-    screen.getByRole('heading', { name: /document certification/i })
+    screen.getByRole('button', { name: /document certification/i })
   ).toBeInTheDocument();
   expect(
-    screen.getByRole('heading', { name: /affidavits & sworn statements/i })
+    screen.getByRole('button', { name: /affidavits & sworn statements/i })
   ).toBeInTheDocument();
 });

--- a/src/components/ServiceItem.jsx
+++ b/src/components/ServiceItem.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import clsx from 'clsx';
+
+export default function ServiceItem({ id, title, desc }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <li className="overflow-hidden rounded border border-platinum">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={`service-desc-${id}`}
+        id={`service-header-${id}`}
+        className="flex w-full items-center justify-between bg-deepgray px-4 py-3 text-left text-platinum hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-silver"
+      >
+        <span className="font-medium">{title}</span>
+        <svg
+          className={clsx('h-5 w-5 transform transition-transform', open ? 'rotate-180 text-silver' : 'text-platinum')}
+          viewBox="0 0 20 20"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        >
+          <path d="M6 8l4 4 4-4" />
+        </svg>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            id={`service-desc-${id}`}
+            role="region"
+            aria-labelledby={`service-header-${id}`}
+            key="content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.3, ease: 'easeOut' }}
+            className="px-4 pb-4 pt-2 text-sm text-platinum"
+          >
+            <p>{desc}</p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </li>
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,3 +14,4 @@ export { default as ChatWidget } from './ChatWidget';
 export { default as ContactForm } from './ContactForm';
 export { default as ContactFields } from './ContactFields';
 export { default as ThankYou } from './ThankYou';
+export { default as ServiceItem } from './ServiceItem';

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -1,4 +1,4 @@
-import { MotionSection, SEO } from '../components';
+import { MotionSection, SEO, ServiceItem } from '../components';
 
 export default function Services() {
   const categories = [
@@ -8,31 +8,14 @@ export default function Services() {
         {
           title: 'Mobile Notary Services',
           desc: 'Convenient on-site notarization at your home, office, or other location.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M12 2a7 7 0 00-7 7c0 5 7 13 7 13s7-8 7-13a7 7 0 00-7-7z" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-              <circle cx="12" cy="9" r="2" fill="currentColor" />
-            </svg>
-          ),
         },
         {
           title: 'General Acknowledgements',
           desc: 'Verification of signatures for a variety of documents.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M5 13l4 4L19 7" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          ),
         },
         {
           title: 'After-Hours & Emergency Notary',
           desc: 'Provide notary services outside regular business hours or on short notice, subject to availability and applicable surcharges.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" fill="none" />
-              <path d="M12 6v6l3 3" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            </svg>
-          ),
         },
       ],
     },
@@ -42,52 +25,22 @@ export default function Services() {
         {
           title: 'Oaths & Affirmations',
           desc: 'Administer legally binding oaths and affirmations for affidavits, statements, and declarations.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M12 6v6l3 3" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-              <path d="M5 19h14" stroke="currentColor" strokeWidth="2" fill="none" strokeLinecap="round" />
-            </svg>
-          ),
         },
         {
           title: 'Affidavits & Sworn Statements',
           desc: 'Preparation and notarization of affidavits and sworn statements.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M4 4h16v16H4z" fill="none" stroke="currentColor" strokeWidth="2" />
-              <path d="M8 8h8M8 12h8M8 16h4" stroke="currentColor" strokeWidth="2" fill="none" />
-            </svg>
-          ),
         },
         {
           title: 'Wills & Trusts',
           desc: 'Execution of wills, living wills, and trust documents.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M6 4h12v16H6z" fill="none" stroke="currentColor" strokeWidth="2" />
-              <path d="M8 8h8" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
         {
           title: 'Power of Attorney',
           desc: 'Preparation and notarization of power of attorney forms.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M12 2v20" stroke="currentColor" strokeWidth="2" />
-              <path d="M5 9l7-7 7 7" fill="none" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
         {
           title: 'Medical Directives',
           desc: 'Notarization of healthcare directives and related documents.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M12 2v20" stroke="currentColor" strokeWidth="2" />
-              <path d="M5 12h14" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
       ],
     },
@@ -97,42 +50,18 @@ export default function Services() {
         {
           title: 'Contracts',
           desc: 'Witnessing and notarizing contract agreements and amendments.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M5 5h14v14H5z" fill="none" stroke="currentColor" strokeWidth="2" />
-              <path d="M9 9h6M9 13h6" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
         {
           title: 'Legal Filings',
           desc: 'Assistance with notarizing and submitting legal documents and filings.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M6 3h12v18H6z" fill="none" stroke="currentColor" strokeWidth="2" />
-              <path d="M6 7h12" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
         {
           title: 'Document Certification',
           desc: 'Certify copies of documents as true and accurate when allowed by law.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <rect x="3" y="3" width="18" height="18" rx="2" ry="2" stroke="currentColor" strokeWidth="2" fill="none" />
-              <path d="M3 9h18M9 21V9" stroke="currentColor" strokeWidth="2" fill="none" />
-            </svg>
-          ),
         },
         {
           title: 'I-9 Employment Verification',
           desc: 'Authorized completion of Form I-9 as an employer agent.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M4 4h16v16H4z" fill="none" stroke="currentColor" strokeWidth="2" />
-              <path d="M9 12h6" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
       ],
     },
@@ -142,20 +71,10 @@ export default function Services() {
         {
           title: 'Deed Transfers',
           desc: 'Notarization services for property deeds and title transfers.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M4 12l8-8 8 8v8H4z" fill="none" stroke="currentColor" strokeWidth="2" />
-            </svg>
-          ),
         },
         {
           title: 'Loan Signing Appointments',
           desc: 'Professional handling of mortgage closings and refinance packages.',
-          icon: (
-            <svg viewBox="0 0 24 24" className="h-6 w-6 text-silver" aria-hidden="true">
-              <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-            </svg>
-          ),
         },
       ],
     },
@@ -179,19 +98,9 @@ export default function Services() {
           {categories.map(({ heading, items }) => (
             <section key={heading} className="flex flex-col gap-6">
               <h2 className="text-2xl font-semibold text-silver">{heading}</h2>
-              <ul className="grid auto-rows-fr gap-8 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-                {items.map(({ title, desc, icon }) => (
-                  <li
-                    key={title}
-                    className="flex h-full flex-col rounded border border-platinum bg-deepgray p-6 shadow-sm transition-transform duration-200 hover:-translate-y-1 hover:bg-charcoal hover:shadow-lg focus-within:ring-2 focus-within:ring-platinum"
-                  >
-                    <div className="flex items-start gap-2">
-                      {icon}
-                      <h3 className="min-w-0 break-words text-lg font-semibold text-platinum sm:text-xl">{title}</h3>
-                    </div>
-                    <div className="my-2 h-px w-full bg-platinum/20" aria-hidden="true" />
-                    <p className="text-sm text-platinum sm:text-base">{desc}</p>
-                  </li>
+              <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+                {items.map(({ title, desc }, idx) => (
+                  <ServiceItem key={title} id={`${heading}-${idx}`} title={title} desc={desc} />
                 ))}
               </ul>
             </section>


### PR DESCRIPTION
## Summary
- reduce services card size and swap to collapsible layout
- add reusable `ServiceItem` component
- export new component and update Services page logic
- update Services tests for new button-based titles

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687359037ea88327882640f3500b3fa8