### PR TITLE
Refine services layout

### DIFF
--- a/src/components/ServiceItem.jsx
+++ b/src/components/ServiceItem.jsx
@@ -5,7 +5,12 @@ import clsx from 'clsx';
 export default function ServiceItem({ id, title, desc }) {
   const [open, setOpen] = useState(false);
   return (
-    <li className="overflow-hidden rounded border border-platinum">
+    <li
+      className={clsx(
+        'overflow-hidden rounded border border-platinum',
+        open && 'col-span-full'
+      )}
+    >
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -98,7 +98,7 @@ export default function Services() {
           {categories.map(({ heading, items }) => (
             <section key={heading} className="flex flex-col gap-6">
               <h2 className="text-2xl font-semibold text-silver">{heading}</h2>
-              <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              <ul className="grid grid-flow-dense gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
                 {items.map(({ title, desc }, idx) => (
                   <ServiceItem key={title} id={`${heading}-${idx}`} title={title} desc={desc} />
                 ))}


### PR DESCRIPTION
## Summary
- ensure Services cards span the full row when opened
- enable grid-gap fill for more stable layout

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_b_68735ed5dde88327a569e850b06c57ac