### PR TITLE
Update Services page layout

### DIFF
--- a/src/__tests__/Services.test.jsx
+++ b/src/__tests__/Services.test.jsx
@@ -19,14 +19,8 @@ test('renders services list with updated offerings', () => {
   expect(
     screen.getByRole('heading', { level: 1, name: /services/i })
   ).toBeInTheDocument();
-  // check that service toggles render as buttons
-  expect(
-    screen.getByRole('button', { name: /after-hours & emergency notary/i })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByRole('button', { name: /document certification/i })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByRole('button', { name: /affidavits & sworn statements/i })
-  ).toBeInTheDocument();
+  // service items should display as simple list entries
+  expect(screen.getByText(/after-hours & emergency notary/i)).toBeInTheDocument();
+  expect(screen.getByText(/document certification/i)).toBeInTheDocument();
+  expect(screen.getByText(/affidavits & sworn statements/i)).toBeInTheDocument();
 });

--- a/src/components/ServiceItem.jsx
+++ b/src/components/ServiceItem.jsx
@@ -1,53 +1,7 @@
-import { useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
-import clsx from 'clsx';
-
-export default function ServiceItem({ id, title, desc }) {
-  const [open, setOpen] = useState(false);
+export default function ServiceItem({ title }) {
   return (
-    <li
-      className={clsx(
-        'overflow-hidden rounded border border-platinum',
-        open && 'col-span-full'
-      )}
-    >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-controls={`service-desc-${id}`}
-        id={`service-header-${id}`}
-        className="flex w-full items-center justify-between bg-deepgray px-4 py-3 text-left text-platinum hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-silver"
-      >
-        <span className="font-medium">{title}</span>
-        <svg
-          className={clsx('h-5 w-5 transform transition-transform', open ? 'rotate-180 text-silver' : 'text-platinum')}
-          viewBox="0 0 20 20"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-        >
-          <path d="M6 8l4 4 4-4" />
-        </svg>
-      </button>
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            id={`service-desc-${id}`}
-            role="region"
-            aria-labelledby={`service-header-${id}`}
-            key="content"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.3, ease: 'easeOut' }}
-            className="px-4 pb-4 pt-2 text-sm text-platinum"
-          >
-            <p>{desc}</p>
-          </motion.div>
-        )}
-      </AnimatePresence>
+    <li className="rounded border border-platinum bg-deepgray p-4 text-center text-platinum transition-colors hover:bg-black">
+      {title}
     </li>
   );
 }

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -5,77 +5,35 @@ export default function Services() {
     {
       heading: 'General Notary',
       items: [
-        {
-          title: 'Mobile Notary Services',
-          desc: 'Convenient on-site notarization at your home, office, or other location.',
-        },
-        {
-          title: 'General Acknowledgements',
-          desc: 'Verification of signatures for a variety of documents.',
-        },
-        {
-          title: 'After-Hours & Emergency Notary',
-          desc: 'Provide notary services outside regular business hours or on short notice, subject to availability and applicable surcharges.',
-        },
+        'Mobile Notary Services',
+        'General Acknowledgements',
+        'After-Hours & Emergency Notary',
       ],
     },
     {
       heading: 'Personal & Family',
       items: [
-        {
-          title: 'Oaths & Affirmations',
-          desc: 'Administer legally binding oaths and affirmations for affidavits, statements, and declarations.',
-        },
-        {
-          title: 'Affidavits & Sworn Statements',
-          desc: 'Preparation and notarization of affidavits and sworn statements.',
-        },
-        {
-          title: 'Wills & Trusts',
-          desc: 'Execution of wills, living wills, and trust documents.',
-        },
-        {
-          title: 'Power of Attorney',
-          desc: 'Preparation and notarization of power of attorney forms.',
-        },
-        {
-          title: 'Medical Directives',
-          desc: 'Notarization of healthcare directives and related documents.',
-        },
+        'Oaths & Affirmations',
+        'Affidavits & Sworn Statements',
+        'Wills & Trusts',
+        'Power of Attorney',
+        'Medical Directives',
       ],
     },
     {
       heading: 'Business & Legal',
       items: [
-        {
-          title: 'Contracts',
-          desc: 'Witnessing and notarizing contract agreements and amendments.',
-        },
-        {
-          title: 'Legal Filings',
-          desc: 'Assistance with notarizing and submitting legal documents and filings.',
-        },
-        {
-          title: 'Document Certification',
-          desc: 'Certify copies of documents as true and accurate when allowed by law.',
-        },
-        {
-          title: 'I-9 Employment Verification',
-          desc: 'Authorized completion of Form I-9 as an employer agent.',
-        },
+        'Contracts',
+        'Legal Filings',
+        'Document Certification',
+        'I-9 Employment Verification',
       ],
     },
     {
       heading: 'Real Estate',
       items: [
-        {
-          title: 'Deed Transfers',
-          desc: 'Notarization services for property deeds and title transfers.',
-        },
-        {
-          title: 'Loan Signing Appointments',
-          desc: 'Professional handling of mortgage closings and refinance packages.',
-        },
+        'Deed Transfers',
+        'Loan Signing Appointments',
       ],
     },
   ];
@@ -99,8 +57,8 @@ export default function Services() {
             <section key={heading} className="flex flex-col gap-6">
               <h2 className="text-2xl font-semibold text-silver">{heading}</h2>
               <ul className="grid grid-flow-dense gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
-                {items.map(({ title, desc }, idx) => (
-                  <ServiceItem key={title} id={`${heading}-${idx}`} title={title} desc={desc} />
+                {items.map((title) => (
+                  <ServiceItem key={title} title={title} />
                 ))}
               </ul>
             </section>


### PR DESCRIPTION
## Summary
- simplify `ServiceItem` component to a static bordered list item
- remove expandable descriptions from Services data
- update Services page to show a simple list
- adjust Services tests for new layout

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6873cbf1f23c832785bccab54f275525