### PR TITLE
Simplify Services list layout

### DIFF
--- a/src/components/ServiceItem.jsx
+++ b/src/components/ServiceItem.jsx
@@ -1,6 +1,8 @@
 export default function ServiceItem({ title }) {
   return (
-    <li className="rounded border border-platinum bg-deepgray p-4 text-center text-platinum transition-colors hover:bg-black">
+    <li
+      className="mx-auto flex min-h-[3rem] w-full max-w-md items-center justify-center rounded border border-platinum bg-deepgray px-4 py-3 text-center text-platinum transition-colors hover:bg-black"
+    >
       {title}
     </li>
   );

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -56,7 +56,7 @@ export default function Services() {
           {categories.map(({ heading, items }) => (
             <section key={heading} className="flex flex-col gap-6">
               <h2 className="text-2xl font-semibold text-silver">{heading}</h2>
-              <ul className="grid grid-flow-dense gap-4 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-4">
+              <ul className="flex flex-col gap-4">
                 {items.map((title) => (
                   <ServiceItem key={title} title={title} />
                 ))}


### PR DESCRIPTION
## Summary
- update ServiceItem layout to keep each box a consistent size
- make the Services list always render one column

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_6873cecf28f883279c4b004fc81402cd