### PR TITLE
Minor entry refactors

### DIFF
--- a/src/404.jsx
+++ b/src/404.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import NotFound from './pages/NotFound';
@@ -6,7 +6,7 @@ import Layout from './components/Layout';
 import './index.css';
 
 createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <Routes>
         <Route element={<Layout />}>
@@ -14,6 +14,6 @@ createRoot(document.getElementById('root')).render(
         </Route>
       </Routes>
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,6 +1,7 @@
+// Capture the year once to avoid recalculating on every render
+const CURRENT_YEAR = new Date().getFullYear();
+
 export default function Footer() {
-  // Cache the year so it doesn't recompute on every render
-  const currentYear = new Date().getFullYear();
   return (
     <footer
       role="contentinfo"
@@ -61,7 +62,7 @@ export default function Footer() {
           </svg>
         </a>
       </p>
-      <p>&copy; {currentYear} Keystone Notary Group, LLC. All rights reserved.</p>
+      <p>&copy; {CURRENT_YEAR} Keystone Notary Group, LLC. All rights reserved.</p>
     </footer>
   );
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 
 createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
+  <StrictMode>
     <BrowserRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <App />
     </BrowserRouter>
-  </React.StrictMode>
+  </StrictMode>
 );


### PR DESCRIPTION
## Summary
- swap to `StrictMode` imports in entry points
- cache current year in Footer

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_687574e49e948327a69ece0b7c2db307