### PR TITLE
Fix contact form button alignment

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -99,7 +99,7 @@ export default function ContactForm({ onSuccess }) {
         </label>
         <button
           type="submit"
-          className="cta-button hover:border-silver hover:text-silver"
+          className="cta-button mx-auto block px-6 py-2 text-base hover:border-silver hover:text-silver"
         >
           Send Message
         </button>


### PR DESCRIPTION
## Summary
- center "Send Message" button under the contact form
- scale button down with smaller padding and font size

## Testing
- `npm run lint`
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_b_687579bc78cc832791933c125b5ff179