### PR TITLE
Introduce white accents across headings and forms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,11 @@ The Keystone brand uses a restrained palette built around charcoal, black, and v
 - **Light Gray** `#CCCCCC`
 - **Medium Gray** `#666666`
 - **Silver** `#bfbfbf`
+- **Pure White** `#ffffff`
+- **Off White** `#f6f6f6`
 - **Metallic Silver** ``
+
+White tones may be used for prominent headings, call-to-action elements,
+and form highlights while maintaining the monochromatic style.
 
 Metallic silver accents are allowed, but gold or other hues should not be introduced. Designs should feel minimalist and professional—mirroring our charcoal matte business cards with silver foil logos. All website updates should maintain this luxurious, monochromatic style.

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -67,7 +67,7 @@ export default function ContactForm({ onSuccess }) {
 
   return (
     <>
-      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
         Contact Us
       </h1>
       <form onSubmit={handleSubmit} className="space-y-6" noValidate>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -52,7 +52,7 @@ export default function Hero() {
         </header>
         <motion.p
           style={{ y: reduce ? 0 : taglineY }}
-          className="text-lg font-light text-silver lg:text-2xl"
+          className="text-lg font-light text-purewhite lg:text-2xl"
         >
           Reliable Mobile Notary Services
         </motion.p>

--- a/src/components/ThankYou.jsx
+++ b/src/components/ThankYou.jsx
@@ -1,7 +1,7 @@
 export default function ThankYou() {
   return (
     <>
-      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
         Thank You
       </h1>
       <p className="text-lg text-platinum">

--- a/src/components/variants.js
+++ b/src/components/variants.js
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const inputStyles = tv({
-  base: 'w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none focus:ring-2 focus:ring-silver transition-colors duration-200',
+  base: 'w-full rounded border border-silver bg-deepgray px-3 py-2 text-purewhite placeholder-platinum focus:border-purewhite focus:outline-none focus:ring-2 focus:ring-purewhite transition-colors duration-200',
   variants: {
     disabled: {
       true: 'opacity-50 cursor-not-allowed',

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -14,7 +14,7 @@ export default function About() {
         className="pointer-events-none absolute inset-0 opacity-20 [background:radial-gradient(circle_at_center,_rgba(255,255,255,0.05),_transparent)]"
       />
       <div className="mx-auto w-full max-w-3xl flex flex-col gap-8">
-        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
           About Us
         </h1>
         <section className="space-y-4">

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -58,7 +58,7 @@ export default function FAQ() {
         path="/faq"
       />
       <div className="mx-auto w-full max-w-3xl flex flex-col gap-8">
-        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
           Frequently Asked Questions
         </h1>
         <ul className="flex flex-col gap-4">

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -16,7 +16,7 @@ export default function NotFound() {
         animate={{ rotate: [0, 5, -5, 0] }}
         transition={{ repeat: Infinity, duration: 8 }}
       />
-      <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
+      <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">404</h1>
       <p className="text-lg text-platinum">Sorry, we can’t find that page.</p>
       <nav aria-label="Helpful links" className="flex flex-col items-center gap-4 sm:flex-row">
         <a

--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -9,7 +9,7 @@ export default function Prices() {
         path="/prices"
       />
       <div className="mx-auto w-full max-w-3xl space-y-8">
-        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
           Keystone Notary Group, LLC – Fee Schedule
         </h1>
         <section aria-labelledby="standard-fees-heading">

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -47,7 +47,7 @@ export default function Services() {
           path="/services"
         />
         <div aria-hidden="true" className="pointer-events-none absolute inset-0 opacity-20 [background:radial-gradient(circle_at_center,_rgba(255,255,255,0.05),_transparent)]" />
-        <h1 className="relative z-10 text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+        <h1 className="relative z-10 text-4xl font-serif font-semibold tracking-wide heading-gradient text-purewhite">
           Our Professional Services
         </h1>
       </MotionSection>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,6 +23,8 @@ export default {
         silver: '#bfbfbf',
         accent: '#bfbfbf',
         accentDark: '#333333',
+        purewhite: '#ffffff',
+        offwhite: '#f6f6f6',
       },
       // Limit container width for consistent layouts across large screens
       container: {


### PR DESCRIPTION
## Summary
- add new `purewhite` and `offwhite` tokens in Tailwind config
- use white for major page headings and hero tagline
- update contact form input styling
- document color updates in brand guidelines

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6875e1355b588327829a2aa617367335