### PR TITLE
Improve text readability

### DIFF
--- a/src/components/ChatWidget.jsx
+++ b/src/components/ChatWidget.jsx
@@ -141,7 +141,7 @@ export default function ChatWidget() {
               role="dialog"
               aria-label="Ask a Notary"
               ref={chatRef}
-              className="fixed bottom-0 left-0 right-0 z-50 m-4 flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[#E5E4E2]/80 bg-black/80 text-platinum shadow-2xl backdrop-blur-md sm:bottom-4 sm:left-auto sm:right-4 sm:w-96"
+              className="fixed bottom-0 left-0 right-0 z-50 m-4 flex max-h-[80vh] w-full max-w-sm flex-col overflow-hidden rounded-2xl border border-[#E5E4E2]/80 bg-black/80 text-lightgray shadow-2xl backdrop-blur-md sm:bottom-4 sm:left-auto sm:right-4 sm:w-96"
               initial={reduce ? false : { opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               exit={reduce ? false : { opacity: 0, y: 20 }}
@@ -164,7 +164,7 @@ export default function ChatWidget() {
                 className="flex-1 space-y-3 overflow-y-auto px-4 py-3 text-sm"
                 aria-live="polite"
               >
-                <p className="text-xs text-platinum">
+                <p className="text-xs text-lightgray">
                   For legal advice or sensitive matters, please call or text directly.
                 </p>
                 <AnimatePresence initial={false}>
@@ -176,7 +176,7 @@ export default function ChatWidget() {
                         {
                           'ml-auto bg-gradient-to-br from-deepgray to-charcoal text-white':
                             msg.from === 'user',
-                          'mr-auto bg-gradient-to-br from-charcoal to-deepgray text-platinum':
+                          'mr-auto bg-gradient-to-br from-charcoal to-deepgray text-lightgray':
                             msg.from === 'bot',
                         },
                       )}
@@ -196,7 +196,7 @@ export default function ChatWidget() {
                   ))}
                 </AnimatePresence>
                 {typing && (
-                  <p aria-label="Typing indicator" className="animate-pulse text-platinum">
+                  <p aria-label="Typing indicator" className="animate-pulse text-lightgray">
                     Typing...
                   </p>
                 )}
@@ -222,7 +222,7 @@ export default function ChatWidget() {
                   name="question"
                   ref={inputRef}
                   type="text"
-                  className="flex-1 rounded-full border border-silver/70 bg-transparent px-3 py-3 text-white placeholder-platinum transition-shadow focus:outline-none focus:ring-2 focus:ring-silver focus:ring-offset-2 focus:ring-offset-black"
+                  className="flex-1 rounded-full border border-silver/70 bg-transparent px-3 py-3 text-white placeholder-lightgray transition-shadow focus:outline-none focus:ring-2 focus:ring-silver focus:ring-offset-2 focus:ring-offset-black"
                   placeholder="Ask a question..."
                   autoComplete="off"
                 />
@@ -234,7 +234,7 @@ export default function ChatWidget() {
                   ➤
                 </button>
               </form>
-              <p className="px-4 py-2 text-center text-2xs text-platinum">
+              <p className="px-4 py-2 text-center text-2xs text-lightgray">
                 Responses are informational and not legal advice.
               </p>
             </motion.div>

--- a/src/components/ContactFields.jsx
+++ b/src/components/ContactFields.jsx
@@ -11,7 +11,7 @@ export default function ContactFields({
   return (
     <fieldset className="space-y-4">
       <label className="block" htmlFor="name">
-        <span className="mb-1 block text-platinum">Full Name</span>
+        <span className="mb-1 block text-lightgray">Full Name</span>
         <input
           id="name"
           name="name"
@@ -29,7 +29,7 @@ export default function ContactFields({
           )}
       </label>
       <label className="block" htmlFor="email">
-        <span className="mb-1 block text-platinum">Email Address</span>
+        <span className="mb-1 block text-lightgray">Email Address</span>
         <input
           id="email"
           name="email"
@@ -47,7 +47,7 @@ export default function ContactFields({
           )}
       </label>
       <label className="block" htmlFor="phone">
-        <span className="mb-1 block text-platinum">Phone Number</span>
+        <span className="mb-1 block text-lightgray">Phone Number</span>
         <input
           id="phone"
           name="phone"
@@ -58,7 +58,7 @@ export default function ContactFields({
         />
       </label>
       <label className="block" htmlFor="documentCategory">
-        <span className="mb-1 block text-platinum">Document Category</span>
+        <span className="mb-1 block text-lightgray">Document Category</span>
         <select
           id="documentCategory"
           name="documentCategory"
@@ -101,10 +101,10 @@ export default function ContactFields({
           }}
           className="h-5 w-5 accent-silver"
         />
-        <span className="text-platinum">I am requesting an appointment.</span>
+        <span className="text-lightgray">I am requesting an appointment.</span>
       </label>
       <label className="block" htmlFor="appointmentType">
-        <span className="mb-1 block text-platinum">Appointment Type</span>
+        <span className="mb-1 block text-lightgray">Appointment Type</span>
         <select
           id="appointmentType"
           name="appointmentType"
@@ -126,7 +126,7 @@ export default function ContactFields({
           )}
       </label>
       <label className="block" htmlFor="date">
-        <span className="mb-1 block text-platinum">Preferred Date</span>
+        <span className="mb-1 block text-lightgray">Preferred Date</span>
         <input
           id="date"
           name="date"
@@ -145,7 +145,7 @@ export default function ContactFields({
           )}
       </label>
       <label className="block" htmlFor="time">
-        <span className="mb-1 block text-platinum">Preferred Time</span>
+        <span className="mb-1 block text-lightgray">Preferred Time</span>
         <input
           id="time"
           name="time"
@@ -164,7 +164,7 @@ export default function ContactFields({
           )}
       </label>
       {!requestAppointment && (
-        <p className="text-xs italic text-platinum">
+        <p className="text-xs italic text-lightgray">
           Enable appointment request above to choose date and time.
         </p>
       )}

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -80,7 +80,7 @@ export default function ContactForm({ onSuccess }) {
           setErrors={setErrors}
         />
         <label className="block" htmlFor="message">
-          <span className="mb-1 block text-platinum">Message</span>
+          <span className="mb-1 block text-lightgray">Message</span>
           <textarea
             id="message"
             name="message"
@@ -104,11 +104,11 @@ export default function ContactForm({ onSuccess }) {
           Send Message
         </button>
       </form>
-      <p className="mt-6 text-center text-sm italic text-platinum">
+      <p className="mt-6 text-center text-sm italic text-lightgray">
         Submitting this form does not guarantee an appointment. All requests are
         subject to confirmation by Keystone Notary Group, LLC.
       </p>
-      <p className="mt-2 text-center text-xs text-platinum">
+      <p className="mt-2 text-center text-xs text-lightgray">
         Keystone Notary Group, LLC is not a law firm and does not provide legal
         advice or services. Please consult an attorney for legal questions or
         document preparation.

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -31,7 +31,7 @@ export default function Credentials({ className = '' }) {
           {credentials.map((cred) => (
             <li key={cred} className="flex items-start">
               <CheckIcon className="mr-2 h-5 w-5 text-silver" aria-hidden="true" />
-              <span className="text-platinum">{cred}</span>
+              <span className="text-lightgray">{cred}</span>
             </li>
           ))}
         </ul>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <footer
       role="contentinfo"
-      className="footer-gradient bg-charcoal py-8 px-4 text-center text-sm text-platinum"
+      className="footer-gradient bg-charcoal py-8 px-4 text-center text-sm text-lightgray"
     >
       <nav aria-label="Footer" className="mb-4 flex justify-center gap-4">
         <a href="/about" aria-label="Footer link to About" className="hover:text-silver">About</a>
@@ -28,7 +28,7 @@ export default function Footer() {
         <a
           href="https://twitter.com"
           aria-label="Twitter"
-          className="text-platinum transition-colors hover:text-silver"
+          className="text-lightgray transition-colors hover:text-silver"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
             <path
@@ -40,7 +40,7 @@ export default function Footer() {
         <a
           href="https://facebook.com"
           aria-label="Facebook"
-          className="text-platinum transition-colors hover:text-silver"
+          className="text-lightgray transition-colors hover:text-silver"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
             <path
@@ -52,7 +52,7 @@ export default function Footer() {
         <a
           href="https://linkedin.com"
           aria-label="LinkedIn"
-          className="text-platinum transition-colors hover:text-silver"
+          className="text-lightgray transition-colors hover:text-silver"
         >
           <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
             <path

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -59,7 +59,7 @@ export default function Hero() {
         <a
           href="tel:2673099000"
           aria-label="Call or text 267-309-9000"
-          className="flex items-center justify-center gap-2 py-2 text-platinum hover:text-silver focus:outline-none focus:ring focus:ring-platinum"
+          className="flex items-center justify-center gap-2 py-2 text-lightgray hover:text-silver focus:outline-none focus:ring focus:ring-platinum"
         >
           <PhoneIcon className="h-5 w-5" />
           <span className="whitespace-nowrap">Call or Text: (267) 309-9000</span>
@@ -73,7 +73,7 @@ export default function Hero() {
         >
           Book Appointment
         </MotionAnchor>
-        <p className="text-xs italic text-platinum">
+        <p className="text-xs italic text-lightgray">
           Bookings are reviewed and confirmed before they’re official.
         </p>
         <a

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -13,7 +13,7 @@ export default function Layout() {
   return (
     <>
       <StructuredData />
-      <div className="flex min-h-screen flex-col bg-charcoal text-platinum">
+      <div className="flex min-h-screen flex-col bg-charcoal text-lightgray">
         {/* Accessibility skip link lets keyboard users bypass repetitive navigation */}
         <a
           href="#content"

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -123,7 +123,7 @@ export default function Navbar() {
           aria-expanded={open}
           className="col-start-3 flex justify-self-end md:hidden landscape-toggle items-center justify-center p-2 focus:outline-none focus:ring-2 focus:ring-platinum"
         >
-          <GridIcon className="h-6 w-6 text-platinum transition-colors hover:text-silver" />
+          <GridIcon className="h-6 w-6 text-lightgray transition-colors hover:text-silver" />
         </button>
         <Link
           to="/"

--- a/src/components/ServiceItem.jsx
+++ b/src/components/ServiceItem.jsx
@@ -1,7 +1,7 @@
 export default function ServiceItem({ title }) {
   return (
     <li
-      className="mx-auto flex min-h-[3rem] w-full max-w-md items-center justify-center rounded border border-platinum bg-deepgray px-4 py-3 text-center text-platinum transition-colors hover:bg-black"
+      className="mx-auto flex min-h-[3rem] w-full max-w-md items-center justify-center rounded border border-platinum bg-deepgray px-4 py-3 text-center text-lightgray transition-colors hover:bg-black"
     >
       {title}
     </li>

--- a/src/components/ThankYou.jsx
+++ b/src/components/ThankYou.jsx
@@ -4,7 +4,7 @@ export default function ThankYou() {
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Thank You
       </h1>
-      <p className="text-lg text-platinum">
+      <p className="text-lg text-lightgray">
         Your message has been received. We will be in touch soon.
       </p>
     </>

--- a/src/components/variants.js
+++ b/src/components/variants.js
@@ -1,7 +1,7 @@
 import { tv } from 'tailwind-variants';
 
 export const inputStyles = tv({
-  base: 'w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-platinum focus:border-silver focus:outline-none focus:ring-2 focus:ring-silver transition-colors duration-200',
+  base: 'w-full rounded border border-platinum bg-deepgray px-3 py-2 text-white placeholder-lightgray focus:border-silver focus:outline-none focus:ring-2 focus:ring-silver transition-colors duration-200',
   variants: {
     disabled: {
       true: 'opacity-50 cursor-not-allowed',
@@ -12,7 +12,7 @@ export const inputStyles = tv({
 export const navLinkStyles = tv({
   // Minimal styling keeps links lightweight while providing clear focus states
   base:
-    'block rounded px-4 py-2 text-lg font-medium text-platinum transition-colors duration-200 hover:text-silver focus:outline-none focus:ring focus:ring-silver',
+    'block rounded px-4 py-2 text-lg font-medium text-lightgray transition-colors duration-200 hover:text-silver focus:outline-none focus:ring focus:ring-silver',
   variants: {
     active: {
       true: 'text-silver underline',

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-charcoal text-platinum font-sans;
+    @apply bg-charcoal text-lightgray font-sans;
     /* Keep the background clean with no decorative textures */
   }
 }

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -19,14 +19,14 @@ export default function About() {
         </h1>
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-silver">Mission</h2>
-          <p className="text-lg text-platinum">
+          <p className="text-lg text-lightgray">
             Keystone Notary Group, LLC is a Pennsylvania-commissioned mobile notary company providing reliable mobile notarization throughout the Greater Philadelphia area.
             Our commitment is to accuracy, confidentiality and convenience for every signing.
           </p>
         </section>
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-silver">Service Area</h2>
-          <ul className="list-disc pl-6 text-platinum">
+          <ul className="list-disc pl-6 text-lightgray">
             <li>Bucks County</li>
             <li>Montgomery County</li>
             <li>Philadelphia County</li>
@@ -36,7 +36,7 @@ export default function About() {
         </section>
         <section className="space-y-4">
           <h2 className="text-2xl font-semibold text-silver">Our Team</h2>
-          <p className="text-lg text-platinum">
+          <p className="text-lg text-lightgray">
             Commissioned by the Commonwealth of Pennsylvania, every notary is an NNA Certified Signing Agent who is bonded and insured with up-to-date background checks and extensive signing experience.
           </p>
         </section>

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -72,13 +72,13 @@ export default function FAQ() {
                 aria-expanded={isOpen}
                 aria-controls={`faq-panel-${idx}`}
                 id={`faq-header-${idx}`}
-                className="flex w-full items-center justify-between bg-deepgray px-4 py-4 text-left text-platinum transition-colors hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-silver"
+                className="flex w-full items-center justify-between bg-deepgray px-4 py-4 text-left text-lightgray transition-colors hover:bg-black focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-silver"
               >
                 <span className="font-medium">{q}</span>
                 <svg
                   className={clsx(
                     'h-5 w-5 transform transition-transform',
-                    isOpen ? 'rotate-180 text-silver' : 'text-platinum',
+                    isOpen ? 'rotate-180 text-silver' : 'text-lightgray',
                   )}
                   viewBox="0 0 20 20"
                   fill="none"
@@ -100,7 +100,7 @@ export default function FAQ() {
                     animate={{ height: 'auto', opacity: 1 }}
                     exit={{ height: 0, opacity: 0 }}
                     transition={{ duration: 0.3, ease: 'easeOut' }}
-                    className="px-4 pb-4 pt-2 text-platinum"
+                    className="px-4 pb-4 pt-2 text-lightgray"
                   >
                     <p>{a}</p>
                   </motion.div>
@@ -110,7 +110,7 @@ export default function FAQ() {
           );
         })}
         </ul>
-        <p className="mt-4 text-platinum">
+        <p className="mt-4 text-lightgray">
           Still have questions?{' '}
           <Link to="/contact" className="underline hover:text-silver">
             Contact us

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,7 +21,7 @@ export default function Home() {
         >
           Why Choose Us?
         </h2>
-        <p className="text-lg text-platinum">
+        <p className="text-lg text-lightgray">
           Keystone Notary Group, LLC provides professional, reliable, and
           convenient mobile notary services. We bring the notary public to you.
         </p>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -17,7 +17,7 @@ export default function NotFound() {
         transition={{ repeat: Infinity, duration: 8 }}
       />
       <h1 className="text-6xl font-serif font-semibold tracking-wide heading-gradient text-silver">404</h1>
-      <p className="text-lg text-platinum">Sorry, we can’t find that page.</p>
+      <p className="text-lg text-lightgray">Sorry, we can’t find that page.</p>
       <nav aria-label="Helpful links" className="flex flex-col items-center gap-4 sm:flex-row">
         <a
           href="https://forms.gle/b1Xg8pYkZABk4wN96"
@@ -31,7 +31,7 @@ export default function NotFound() {
           Return Home
         </Link>
       </nav>
-      <p className="mt-4 text-xs italic text-platinum">
+      <p className="mt-4 text-xs italic text-lightgray">
         All bookings are reviewed and confirmed before they are finalized.
       </p>
     </MotionSection>

--- a/src/pages/Prices.jsx
+++ b/src/pages/Prices.jsx
@@ -16,7 +16,7 @@ export default function Prices() {
           <h2 id="standard-fees-heading" className="mb-2 text-2xl font-semibold text-silver">
             Standard Notary Fees
           </h2>
-          <ul className="list-disc pl-5 text-platinum space-y-1">
+          <ul className="list-disc pl-5 text-lightgray space-y-1">
             <li>Notarial Act (per signature/seal): $5</li>
             <li>Oath or Affirmation: $5</li>
             <li>Document/Copy Certification: $5</li>
@@ -26,7 +26,7 @@ export default function Prices() {
           <h2 id="travel-fees-heading" className="mb-2 text-2xl font-semibold text-silver">
             Mobile/Travel Fees
           </h2>
-          <ul className="list-disc pl-5 text-platinum space-y-1">
+          <ul className="list-disc pl-5 text-lightgray space-y-1">
             <li>Up to 10 miles: $35</li>
             <li>11–20 miles: $45</li>
             <li>21–30 miles: $55</li>
@@ -37,7 +37,7 @@ export default function Prices() {
           <h2 id="surcharges-heading" className="mb-2 text-2xl font-semibold text-silver">
             Surcharges
           </h2>
-          <ul className="list-disc pl-5 text-platinum space-y-1">
+          <ul className="list-disc pl-5 text-lightgray space-y-1">
             <li>After-hours (after 6pm or weekends): +$35</li>
             <li>Late night/major holiday: +$60</li>
             <li>Emergency/rush (within 2 hours): +$100</li>
@@ -48,7 +48,7 @@ export default function Prices() {
           <h2 id="specialized-heading" className="mb-2 text-2xl font-semibold text-silver">
             Specialized Services
           </h2>
-          <ul className="list-disc pl-5 text-platinum space-y-1">
+          <ul className="list-disc pl-5 text-lightgray space-y-1">
             <li>Loan signing / Real estate closing (buyer/seller/refi): $125–$175 (varies by package, call for quote)</li>
             <li>Complex signings: Quoted</li>
             <li>Deed-only appointment: $85</li>
@@ -56,7 +56,7 @@ export default function Prices() {
         </section>
         <section aria-labelledby="notes-heading">
           <h2 id="notes-heading" className="mb-2 text-2xl font-semibold text-silver">Notes</h2>
-          <ul className="list-disc pl-5 text-platinum space-y-1">
+          <ul className="list-disc pl-5 text-lightgray space-y-1">
             <li>All appointments must be confirmed.</li>
             <li>Payment accepted: Cash, check, card, or Venmo.</li>
             <li>Valid, unexpired government-issued photo ID is required.</li>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,6 +21,7 @@ export default {
         deepgray: '#1A1A1A',
         platinum: '#999999',
         silver: '#bfbfbf',
+        lightgray: '#CCCCCC',
         accent: '#bfbfbf',
         accentDark: '#333333',
       },


### PR DESCRIPTION
## Summary
- add `lightgray` to the Tailwind palette
- lighten global body text color
- update components and pages to use `text-lightgray`
- adjust placeholders and nav link styles for consistent contrast

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6876d229cdf08327b3c8c269e95aeb26