### PR TITLE
Fix duplicate sitemap link

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     <meta name="twitter:image" content="/logo.svg" />
     <link rel="canonical" href="https://www.keystonenotarygroup.com/" />
     <link rel="robots" href="/robots.txt" />
-    <link rel="sitemap" type="application/xml" href="/sitemap.xml" />
     <!-- System fonts are used to avoid remote font requests -->
     <!-- Favicons -->
     <link rel="icon" href="/favicon.ico" sizes="any" />


### PR DESCRIPTION
## Summary
- remove manual sitemap link from `index.html`
- rely on vite plugin to inject sitemap link while keeping robots link

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6876e8261ee88327a836d81cbfb849b4