### PR TITLE
Add landscape viewport test coverage

### DIFF
--- a/src/__tests__/Navbar.test.jsx
+++ b/src/__tests__/Navbar.test.jsx
@@ -2,6 +2,17 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { MemoryRouter } from "react-router-dom";
 import { Navbar } from "../components";
+import "../index.css";
+
+function setViewport(width, height) {
+  window.innerWidth = width;
+  window.innerHeight = height;
+  window.dispatchEvent(new Event("resize"));
+}
+
+afterEach(() => {
+  setViewport(1024, 768);
+});
 
 describe("Navbar component", () => {
   test("toggles mobile menu", async () => {
@@ -71,5 +82,25 @@ describe("Navbar component", () => {
     expect(brand).toHaveClass("landscape-brand");
     const list = screen.getByRole("list");
     expect(list).toHaveClass("landscape-links");
+  });
+
+
+  test("menu stays open when rotating to landscape mobile", async () => {
+    setViewport(375, 640);
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <Navbar />
+      </MemoryRouter>,
+    );
+    const toggleButton = screen.getByRole("button", { name: /toggle navigation/i });
+    fireEvent.click(toggleButton);
+    expect(screen.getByRole("navigation", { name: /mobile navigation/i })).toBeInTheDocument();
+    act(() => {
+      setViewport(812, 390);
+      window.dispatchEvent(new Event("orientationchange"));
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("navigation", { name: /mobile navigation/i })).toBeInTheDocument(),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- import global styles for testing
- add helper to set viewport size
- ensure menu stays open on small landscape screens

## Testing
- `npm run test:run --silent`
- `npm run lint`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_6876e9a0875c8327b91ed52b5a6e918b