### PR TITLE
Add E2E test for ContactForm

### DIFF
--- a/src/__tests__/ContactForm.e2e.test.jsx
+++ b/src/__tests__/ContactForm.e2e.test.jsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Contact from '../pages/Contact';
+
+function setViewport(width, height = 768) {
+  window.innerWidth = width;
+  window.innerHeight = height;
+  window.dispatchEvent(new Event('resize'));
+}
+
+const viewports = [375, 1024];
+
+describe('ContactForm end-to-end', () => {
+  test.each(viewports)('simple message submission at %ipx', async (width) => {
+    setViewport(width);
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <Contact />
+      </MemoryRouter>,
+    );
+
+    const submit = screen.getByRole('button', { name: /send message/i });
+    fireEvent.click(submit);
+
+    expect(await screen.findByText(/full name is required/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/full name/i)).toHaveFocus();
+
+    fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: 'John Doe' } });
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'john@example.com' } });
+    fireEvent.change(screen.getByLabelText(/document category/i), { target: { value: 'personal' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Hello' } });
+
+    fireEvent.click(submit);
+
+    expect(await screen.findByRole('heading', { name: /thank you/i })).toHaveFocus();
+    expect(screen.getByText(/your message has been received/i)).toBeInTheDocument();
+  });
+
+  test.each(viewports)('appointment request submission at %ipx', async (width) => {
+    setViewport(width);
+    render(
+      <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
+        <Contact />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByLabelText(/i am requesting an appointment/i));
+    const submit = screen.getByRole('button', { name: /send message/i });
+    fireEvent.click(submit);
+
+    expect(await screen.findByText(/full name is required/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/full name/i)).toHaveFocus();
+
+    fireEvent.change(screen.getByLabelText(/full name/i), { target: { value: 'Jane Doe' } });
+    fireEvent.change(screen.getByLabelText(/email address/i), { target: { value: 'jane@example.com' } });
+    fireEvent.change(screen.getByLabelText(/document category/i), { target: { value: 'business' } });
+    fireEvent.change(screen.getByLabelText(/appointment type/i), { target: { value: 'remote' } });
+    fireEvent.change(screen.getByLabelText(/preferred date/i), { target: { value: '2025-01-01' } });
+    fireEvent.change(screen.getByLabelText(/preferred time/i), { target: { value: '13:30' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Need remote signing' } });
+
+    fireEvent.click(submit);
+
+    expect(await screen.findByRole('heading', { name: /thank you/i })).toHaveFocus();
+    expect(screen.getByText(/your message has been received/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/ContactFields.jsx
+++ b/src/components/ContactFields.jsx
@@ -15,6 +15,7 @@ export default function ContactFields({
   requestAppointment,
   setRequestAppointment,
   setErrors,
+  fieldRefs,
 }) {
   return (
     <fieldset className="space-y-4">
@@ -28,6 +29,7 @@ export default function ContactFields({
           name="name"
           type="text"
           required
+          ref={(el) => (fieldRefs.current.name = el)}
           value={formData.name}
           onChange={onChange}
           aria-invalid={!!errors.name}
@@ -49,6 +51,7 @@ export default function ContactFields({
           name="email"
           type="email"
           required
+          ref={(el) => (fieldRefs.current.email = el)}
           value={formData.email}
           onChange={onChange}
           aria-invalid={!!errors.email}
@@ -83,6 +86,7 @@ export default function ContactFields({
           id="documentCategory"
           name="documentCategory"
           required
+          ref={(el) => (fieldRefs.current.documentCategory = el)}
           value={formData.documentCategory}
           onChange={onChange}
           aria-invalid={!!errors.documentCategory}
@@ -133,6 +137,7 @@ export default function ContactFields({
           name="appointmentType"
           disabled={!requestAppointment}
           required={requestAppointment}
+          ref={(el) => (fieldRefs.current.appointmentType = el)}
           value={formData.appointmentType}
           onChange={onChange}
           aria-invalid={!!errors.appointmentType}
@@ -159,6 +164,7 @@ export default function ContactFields({
           type="date"
           disabled={!requestAppointment}
           required={requestAppointment}
+          ref={(el) => (fieldRefs.current.date = el)}
           value={formData.date}
           onChange={onChange}
           aria-invalid={!!errors.date}
@@ -181,6 +187,7 @@ export default function ContactFields({
           type="time"
           disabled={!requestAppointment}
           required={requestAppointment}
+          ref={(el) => (fieldRefs.current.time = el)}
           value={formData.time}
           onChange={onChange}
           aria-invalid={!!errors.time}

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import ContactFields from './ContactFields';
 import { inputStyles } from './variants';
 
@@ -15,6 +15,16 @@ export default function ContactForm({ onSuccess }) {
     message: '',
   });
   const [errors, setErrors] = useState({});
+
+  const fieldRefs = useRef({
+    name: null,
+    email: null,
+    documentCategory: null,
+    appointmentType: null,
+    date: null,
+    time: null,
+    message: null,
+  });
 
   const validate = () => {
     const newErrors = {};
@@ -59,6 +69,8 @@ export default function ContactForm({ onSuccess }) {
     const validation = validate();
     if (Object.keys(validation).length > 0) {
       setErrors(validation);
+      const first = Object.keys(validation)[0];
+      fieldRefs.current[first]?.focus();
       return;
     }
     setErrors({});
@@ -78,6 +90,7 @@ export default function ContactForm({ onSuccess }) {
           requestAppointment={requestAppointment}
           setRequestAppointment={setRequestAppointment}
           setErrors={setErrors}
+          fieldRefs={fieldRefs}
         />
         <label className="block" htmlFor="message">
           <span className="mb-1 block text-lightgray">Message</span>
@@ -86,6 +99,7 @@ export default function ContactForm({ onSuccess }) {
             name="message"
             required
             rows="4"
+            ref={(el) => (fieldRefs.current.message = el)}
             value={formData.message}
             onChange={handleChange}
             aria-invalid={!!errors.message}

--- a/src/components/ThankYou.jsx
+++ b/src/components/ThankYou.jsx
@@ -1,7 +1,19 @@
+import { useEffect, useRef } from 'react';
+
 export default function ThankYou() {
+  const headingRef = useRef(null);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
   return (
     <>
-      <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
+      <h1
+        ref={headingRef}
+        tabIndex="-1"
+        className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver"
+      >
         Thank You
       </h1>
       <p className="text-lg text-lightgray">


### PR DESCRIPTION
## Summary
- focus invalid fields on ContactForm submit
- focus ThankYou heading when rendered
- wire up refs for all ContactForm fields
- add e2e tests covering simple messages and appointment requests

## Testing
- `yarn lint`
- `yarn test:run`


------
https://chatgpt.com/codex/tasks/task_b_6876ecb65b48832783e28da9e7b06310