### PR TITLE
Fix missing credentials section

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -3,12 +3,14 @@ import MotionSection from './MotionSection';
 import clsx from 'clsx';
 
 // Provide optional className for additional layout control
+const credentials = [
+  'Licensed & Bonded',
+  'Certified Signing Agent',
+  'Member of National Notary Association',
+];
+
+// Reusable credentials block styled like other sections
 export default function Credentials({ className = '' }) {
-  const credentials = [
-    'Licensed & Bonded',
-    'Certified Signing Agent',
-    'Member of National Notary Association',
-  ];
 
   return (
     // Top margin keeps breathing room from prior section
@@ -35,6 +37,11 @@ export default function Credentials({ className = '' }) {
             </li>
           ))}
         </ul>
+        {/* Subtle divider to separate this block from surrounding sections */}
+        <div
+          aria-hidden="true"
+          className="mt-8 h-px w-full bg-gradient-to-r from-transparent via-silver to-transparent"
+        />
       </div>
     </MotionSection>
   );


### PR DESCRIPTION
## Summary
- add reusable `Credentials` component to display notary credentials
- include subtle divider for section spacing

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_68785d59e7608327999dbafe90d2f212