### PR TITLE
Fix credentials copy

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -4,9 +4,9 @@ import clsx from 'clsx';
 
 // Provide optional className for additional layout control
 const credentials = [
-  'Licensed & Bonded',
-  'Certified Signing Agent',
-  'Member of National Notary Association',
+  'Commissioned Notary Public',
+  'NNA Certified Notary Signing Agent',
+  'Bonded & Insured',
 ];
 
 // Reusable credentials block styled like other sections
@@ -37,11 +37,6 @@ export default function Credentials({ className = '' }) {
             </li>
           ))}
         </ul>
-        {/* Subtle divider to separate this block from surrounding sections */}
-        <div
-          aria-hidden="true"
-          className="mt-8 h-px w-full bg-gradient-to-r from-transparent via-silver to-transparent"
-        />
       </div>
     </MotionSection>
   );


### PR DESCRIPTION
## Summary
- revise credentials language to show notary commission and insurance status
- remove extra divider beneath the credentials section

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6878605d74488327838d827bb58008ab