### PR TITLE
Design refinements and form cleanup

### DIFF
--- a/src/components/ContactFields.jsx
+++ b/src/components/ContactFields.jsx
@@ -127,78 +127,79 @@ export default function ContactFields({
         />
         <span className="text-lightgray">I am requesting an appointment.</span>
       </label>
-      <label className="block" htmlFor="appointmentType">
-        <span className="mb-1 flex items-center gap-2 text-lightgray">
-          <CalendarIcon className="h-5 w-5 text-silver" aria-hidden="true" />
-          Appointment Type
-        </span>
-        <select
-          id="appointmentType"
-          name="appointmentType"
-          disabled={!requestAppointment}
-          required={requestAppointment}
-          ref={(el) => (fieldRefs.current.appointmentType = el)}
-          value={formData.appointmentType}
-          onChange={onChange}
-          aria-invalid={!!errors.appointmentType}
-          className={inputStyles()}
-        >
-          <option value="">Select type</option>
-          <option value="in_person">In-Person</option>
-          <option value="remote">Remote/Online</option>
-        </select>
-          {errors.appointmentType && (
-            <p role="alert" className="mt-1 text-sm text-silver">
-              {errors.appointmentType}
-            </p>
-          )}
-      </label>
-      <label className="block" htmlFor="date">
-        <span className="mb-1 flex items-center gap-2 text-lightgray">
-          <CalendarIcon className="h-5 w-5 text-silver" aria-hidden="true" />
-          Preferred Date
-        </span>
-        <input
-          id="date"
-          name="date"
-          type="date"
-          disabled={!requestAppointment}
-          required={requestAppointment}
-          ref={(el) => (fieldRefs.current.date = el)}
-          value={formData.date}
-          onChange={onChange}
-          aria-invalid={!!errors.date}
-          className={inputStyles()}
-        />
-          {errors.date && (
-            <p role="alert" className="mt-1 text-sm text-silver">
-              {errors.date}
-            </p>
-          )}
-      </label>
-      <label className="block" htmlFor="time">
-        <span className="mb-1 flex items-center gap-2 text-lightgray">
-          <ClockIcon className="h-5 w-5 text-silver" aria-hidden="true" />
-          Preferred Time
-        </span>
-        <input
-          id="time"
-          name="time"
-          type="time"
-          disabled={!requestAppointment}
-          required={requestAppointment}
-          ref={(el) => (fieldRefs.current.time = el)}
-          value={formData.time}
-          onChange={onChange}
-          aria-invalid={!!errors.time}
-          className={inputStyles()}
-        />
-          {errors.time && (
-            <p role="alert" className="mt-1 text-sm text-silver">
-              {errors.time}
-            </p>
-          )}
-      </label>
+      {requestAppointment && (
+        <>
+          <label className="block" htmlFor="appointmentType">
+            <span className="mb-1 flex items-center gap-2 text-lightgray">
+              <CalendarIcon className="h-5 w-5 text-silver" aria-hidden="true" />
+              Appointment Type
+            </span>
+            <select
+              id="appointmentType"
+              name="appointmentType"
+              required
+              ref={(el) => (fieldRefs.current.appointmentType = el)}
+              value={formData.appointmentType}
+              onChange={onChange}
+              aria-invalid={!!errors.appointmentType}
+              className={inputStyles()}
+            >
+              <option value="">Select type</option>
+              <option value="in_person">In-Person</option>
+              <option value="remote">Remote/Online</option>
+            </select>
+            {errors.appointmentType && (
+              <p role="alert" className="mt-1 text-sm text-silver">
+                {errors.appointmentType}
+              </p>
+            )}
+          </label>
+          <label className="block" htmlFor="date">
+            <span className="mb-1 flex items-center gap-2 text-lightgray">
+              <CalendarIcon className="h-5 w-5 text-silver" aria-hidden="true" />
+              Preferred Date
+            </span>
+            <input
+              id="date"
+              name="date"
+              type="date"
+              required
+              ref={(el) => (fieldRefs.current.date = el)}
+              value={formData.date}
+              onChange={onChange}
+              aria-invalid={!!errors.date}
+              className={inputStyles()}
+            />
+            {errors.date && (
+              <p role="alert" className="mt-1 text-sm text-silver">
+                {errors.date}
+              </p>
+            )}
+          </label>
+          <label className="block" htmlFor="time">
+            <span className="mb-1 flex items-center gap-2 text-lightgray">
+              <ClockIcon className="h-5 w-5 text-silver" aria-hidden="true" />
+              Preferred Time
+            </span>
+            <input
+              id="time"
+              name="time"
+              type="time"
+              required
+              ref={(el) => (fieldRefs.current.time = el)}
+              value={formData.time}
+              onChange={onChange}
+              aria-invalid={!!errors.time}
+              className={inputStyles()}
+            />
+            {errors.time && (
+              <p role="alert" className="mt-1 text-sm text-silver">
+                {errors.time}
+              </p>
+            )}
+          </label>
+        </>
+      )}
       {!requestAppointment && (
         <p className="text-xs italic text-lightgray">
           Enable appointment request above to choose date and time.

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -82,7 +82,7 @@ export default function ContactForm({ onSuccess }) {
       <h1 className="text-4xl font-serif font-semibold tracking-wide heading-gradient text-silver">
         Contact Us
       </h1>
-      <form onSubmit={handleSubmit} className="space-y-6" noValidate>
+      <form onSubmit={handleSubmit} className="space-y-8" noValidate>
         <ContactFields
           formData={formData}
           errors={errors}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -63,6 +63,14 @@ export default function Navbar() {
 
   const linkClasses = ({ isActive }) => navLinkStyles({ active: isActive });
 
+  // Prevent background scrolling when mobile menu is open
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [open]);
+
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 10);

--- a/src/components/variants.js
+++ b/src/components/variants.js
@@ -22,4 +22,4 @@ export const navLinkStyles = tv({
 });
 
 // Consistent vertical rhythm for sections across the site
-export const sectionSpacing = 'py-12 sm:py-16';
+export const sectionSpacing = 'py-16 sm:py-20 md:py-24';

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,7 @@
 
 @layer base {
   body {
-    @apply bg-charcoal text-lightgray font-sans;
+    @apply bg-charcoal text-lightgray font-sans leading-relaxed;
     /* Keep the background clean with no decorative textures */
   }
 }
@@ -25,7 +25,7 @@
   }
 
   .cta-button {
-    @apply relative inline-block rounded border border-silver bg-gradient-to-br from-accentDark via-deepgray to-black px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus:ring-2 focus:ring-silver hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95;
+    @apply relative inline-block rounded border border-silver bg-gradient-to-br from-accentDark via-deepgray to-black px-8 py-3 text-lg font-medium text-white shadow-md transition-transform duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-silver hover:shadow-lg hover:-translate-y-1 hover:scale-105 active:scale-95 ring-1 ring-silver/30 hover:ring-silver;
     /* Buttons use a dark silver gradient for readability */
   }
 

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -21,7 +21,7 @@ export default function Contact() {
 
   if (submitted) {
     return (
-      <MotionSection className={`container space-y-6 ${sectionSpacing}`}>
+      <MotionSection className={`container space-y-8 ${sectionSpacing}`}>
         <SEO
           title="Contact Keystone Notary Group | Schedule a Notary"
           description="Request a mobile notary appointment or ask questions through our contact form."


### PR DESCRIPTION
## Summary
- increase global section spacing
- relax body leading and tune CTA button styles
- lock body scroll when the mobile menu is open
- hide appointment fields until requested
- widen spacing on contact page and form

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_68786dc81ea88327b4f7082f97e3c281