### PR TITLE
Refine hero layout

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -11,7 +11,7 @@ export default function Hero() {
   const logoY = useTransform(scrollY, [0, 300], [0, reduce ? 0 : -40]);
   const taglineY = useTransform(scrollY, [0, 200], [0, reduce ? 0 : -10]);
   return (
-    <section className="hero-layer relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-black px-4 text-center sm:px-8">
+    <section className="hero-layer relative flex min-h-screen w-full items-center justify-center overflow-hidden bg-[#0D0B0A] px-4 text-center sm:px-8">
       {/* Gradient overlay improves text legibility without obscuring background */}
       <div className="absolute inset-0 bg-gradient-to-b from-black via-black/70 to-transparent" />
       <motion.div
@@ -38,7 +38,7 @@ export default function Hero() {
               alt="Keystone Notary Group logo"
               width="1024"
               height="1024"
-              className="h-auto w-72 max-w-full sm:w-80 md:w-96 lg:w-[30rem]"
+              className="max-h-[75vh] w-auto max-w-full"
               draggable={false}
             />
           </motion.div>


### PR DESCRIPTION
## Summary
- darken hero background to match logo transparency
- scale hero logo responsively to fill most of the viewport

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68787405223c8327a9f96fa8ae13ea00