### PR TITLE
Improve hero image scaling and credentials divider

### DIFF
--- a/src/__tests__/Credentials.test.jsx
+++ b/src/__tests__/Credentials.test.jsx
@@ -15,6 +15,11 @@ describe('Credentials component', () => {
     expect(items).toHaveLength(3);
   });
 
+  test('includes a divider line', () => {
+    render(<Credentials />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
   const viewports = [320, 640, 1024, 1280];
 
   test.each(viewports)('renders correctly at %ipx viewport', (width) => {

--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -21,13 +21,14 @@ export default function Credentials({ className = '' }) {
         className,
       )}
     >
-      <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-center gap-6">
         <h2
           id="credentials-heading"
           className="w-full text-3xl font-serif font-semibold tracking-wide heading-gradient text-silver"
         >
           Credentials
         </h2>
+        <hr className="my-6 h-px w-full border-0 bg-silver/50" />
 
         <ul className="mx-auto flex w-max flex-col items-start gap-4">
           {credentials.map((cred) => (

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -18,7 +18,7 @@ export default function Hero() {
         initial={reduce ? false : { opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.8 }}
-        className="relative z-10 mx-auto flex w-full max-w-screen-xl flex-col items-center gap-8 px-4 sm:px-8 lg:gap-10"
+        className="relative z-10 mx-auto flex w-full max-w-screen-xl flex-col items-center gap-6 sm:gap-8 lg:gap-10 px-4 sm:px-8"
       >
         {/*
           Group brand elements for easier layout tuning and animation hooks.
@@ -38,7 +38,7 @@ export default function Hero() {
               alt="Keystone Notary Group logo"
               width="1440"
               height="600"
-              className="w-full max-w-screen-lg object-contain"
+              className="w-full max-w-screen-xl object-contain"
               draggable={false}
             />
           </motion.div>


### PR DESCRIPTION
## Summary
- let hero image expand to screen width and tighten spacing
- add divider line under Credentials heading
- verify divider via new unit test

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6878a72357988327a612279b1af00c14