### PR TITLE
Fix credentials divider style

### DIFF
--- a/src/components/Credentials.jsx
+++ b/src/components/Credentials.jsx
@@ -28,7 +28,7 @@ export default function Credentials({ className = '' }) {
         >
           Credentials
         </h2>
-        <hr className="my-6 h-px w-full border-0 bg-silver/50" />
+        <hr className="section-divider" />
 
         <ul className="mx-auto flex w-max flex-col items-start gap-4">
           {credentials.map((cred) => (

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,12 @@
     background-image: linear-gradient(to right, transparent, #bfbfbf, transparent);
   }
 
+  /* Horizontal gradient line used as section divider */
+  .section-divider {
+    @apply my-6 h-px w-full border-0;
+    background-image: linear-gradient(to right, transparent, #bfbfbf, transparent);
+  }
+
 
   @media (orientation: landscape) and (max-height: 500px) {
     .why-heading {


### PR DESCRIPTION
## Summary
- create `section-divider` style for matching decorative lines
- apply new divider style in `Credentials`

## Testing
- `npm run lint`
- `npm run test:run`
- `npm run build`
- `npm run preview`

------
https://chatgpt.com/codex/tasks/task_b_6878c511646083278d8e2e9eca1d81fb